### PR TITLE
Add section schema and posted answers to error response

### DIFF
--- a/middleware/error-handler/index.js
+++ b/middleware/error-handler/index.js
@@ -110,8 +110,7 @@ module.exports = async (err, req, res, next) => {
         error.errors.push(...jsonApiErrors);
         error.meta = {
             schema: errorInfo.schema,
-            answers: errorInfo.answers,
-            canswers: errorInfo.coercedAnswers
+            answers: errorInfo.answers
         };
 
         return res.status(400).json(error);

--- a/middleware/error-handler/index.js
+++ b/middleware/error-handler/index.js
@@ -20,50 +20,22 @@ module.exports = async (err, req, res, next) => {
         return res.status(400).json(error);
     }
 
-    /*
-        {
-            "stack": "Error: should be equal to one of the allowed values\n    at /usr/src/app/node_modules/express-openapi-validator/dist/middlewares/openapi.request.validator.js:57:32\n    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)\n    at /usr/src/app/node_modules/express/lib/router/index.js:284:7\n    at Function.process_params (/usr/src/app/node_modules/express/lib/router/index.js:335:12)\n    at next (/usr/src/app/node_modules/express/lib/router/index.js:275:10)\n    at /usr/src/app/node_modules/express-openapi-validator/dist/middlewares/openapi.multipart.js:40:13\n    at Layer.handle [as handle_request] (/usr/src/app/node_modules/express/lib/router/layer.js:95:5)\n    at trim_prefix (/usr/src/app/node_modules/express/lib/router/index.js:317:13)",
-            "message": "should be equal to one of the allowed values",
-            "status": 400,
-            "errors": [
-                {
-                    "path": "data.type",
-                    "errorCode": "enum.openapi.validation",
-                    "message": "should be equal to one of the allowed values",
-                    "location": "body"
-                },
-                {
-                    "path": "data.attributes.templateName",
-                    "errorCode": "type.openapi.validation",
-                    "message": "should be string",
-                    "location": "body"
-                }
-            ],
-            "name": "Error"
-        }
-
-       {
-        "errors": [
-            {
-            "status": "403",
-            "source": { "pointer": "/data/attributes/secretPowers" },
-            "detail": "Editing secret powers is not authorized on Sundays."
-            },
-            {
-            "status": "422",
-            "source": { "pointer": "/data/attributes/volume" },
-            "detail": "Volume does not, in fact, go to 11."
-            },
-            {
-            "status": "500",
-            "source": { "pointer": "/data/attributes/reputation" },
-            "title": "The backend responded with an error",
-            "detail": "Reputation service not responding after three requests."
-            }
-        ]
-        }
-    */
-    // handle express-openapi-validator request errors
+    // Convert express-openapi-validator errors to JSON:API format
+    // express-openapi-validator errors format:
+    // [
+    //     {
+    //         "path": "data.type",
+    //         "errorCode": "enum.openapi.validation",
+    //         "message": "should be equal to one of the allowed values",
+    //         "location": "body"
+    //     },
+    //     {
+    //         "path": "data.attributes.templateName",
+    //         "errorCode": "type.openapi.validation",
+    //         "message": "should be string",
+    //         "location": "body"
+    //     }
+    // ]
     if (err.status === 400) {
         err.errors.forEach(errorObj => {
             error.errors.push({
@@ -77,12 +49,70 @@ module.exports = async (err, req, res, next) => {
         return res.status(400).json(error);
     }
 
+    // Convert ajv errors to JSON:API format
+    // AJV errors format:
+    // [
+    //     {
+    //         keyword: "additionalProperties",
+    //         dataPath: "",
+    //         schemaPath: "#/additionalProperties",
+    //         params: {
+    //         additionalProperty: "q-applicant-british-citizen-or-eu-nationalz"
+    //         },
+    //         message: "should NOT have additional properties"
+    //     },
+    //     {
+    //         keyword: "additionalProperties",
+    //         dataPath: "",
+    //         schemaPath: "#/additionalProperties",
+    //         params: {
+    //         additionalProperty: "foo"
+    //         },
+    //         message: "should NOT have additional properties"
+    //     },
+    //     {
+    //         keyword: "errorMessage",
+    //         dataPath: "",
+    //         schemaPath: "#/errorMessage",
+    //         params: {
+    //         errors: [
+    //             {
+    //             keyword: "required",
+    //             dataPath: "",
+    //             schemaPath: "#/required",
+    //             params: {
+    //                 missingProperty: "q-applicant-british-citizen-or-eu-national"
+    //             },
+    //             message:
+    //                 "should have required property 'q-applicant-british-citizen-or-eu-national'"
+    //             }
+    //         ]
+    //         },
+    //         message: "Select yes if you are a British citizen or EU national"
+    //     }
+    // ]
     if (err.name === 'JSONSchemaValidationError') {
-        error.errors.push({
+        const errorInfo = VError.info(err);
+        const jsonApiErrors = errorInfo.schemaErrors.map(errorObj => ({
             status: 400,
-            title: 'JSONSchemaValidationError',
-            detail: VError.info(err).schemaErrors
-        });
+            title: '400 Bad Request',
+            detail: errorObj.message,
+            code: errorObj.keyword,
+            // The validation is happening on the properties of /data/attributes. This causes the dataPath
+            // to be empty as it's technically the top level. Prefix all pointers with the parent path.
+            source: {pointer: `/data/attributes${errorObj.dataPath}`},
+            meta: {
+                // include the raw ajv error
+                raw: errorObj
+            }
+        }));
+
+        error.errors.push(...jsonApiErrors);
+        error.meta = {
+            schema: errorInfo.schema,
+            answers: errorInfo.answers,
+            canswers: errorInfo.coercedAnswers
+        };
 
         return res.status(400).json(error);
     }

--- a/openapi/src/json-schemas/_questionnaires_{questionnaireId}_sections_{sectionId}_answers/post/req/201.json
+++ b/openapi/src/json-schemas/_questionnaires_{questionnaireId}_sections_{sectionId}_answers/post/req/201.json
@@ -13,14 +13,7 @@
                     "const": "answers"
                 },
                 "attributes": {
-                    "type": "object",
-                    "additionalProperties": false,
-                    "properties": {
-                        "case-reference": {
-                            "type": "string",
-                            "pattern": "^[0-9]{2}\\\\[0-9]{6}$"
-                        }
-                    }
+                    "type": "object"
                 }
             }
         }

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -69,17 +69,11 @@ function createQuestionnaireService(spec) {
                 context: currentSection.context
             };
         } else {
-            // A section id can be either format: p-some-id or p--some-id
-            // Both formats will never coexist so we can safely check for either
-            // PITA!
-            section = qRouter.current(`p-${sectionId}`);
+            // Ensure the requested sectionId is available
+            section = qRouter.current(sectionId);
 
             if (!section) {
-                section = qRouter.current(`p--${sectionId}`);
-
-                if (!section) {
-                    throw new VError(`Section "${sectionId}" not found`);
-                }
+                throw new VError(`Section "${sectionId}" not found`);
             }
         }
 
@@ -89,6 +83,8 @@ function createQuestionnaireService(spec) {
     async function createAnswers(questionnaireId, sectionId, answers) {
         // TODO: throw if more than one request to create same answers
 
+        // Make a copy of the supplied answers. These will be returned if they fail validation
+        const rawAnswers = JSON.parse(JSON.stringify(answers));
         let answerResource;
 
         try {
@@ -106,6 +102,7 @@ function createQuestionnaireService(spec) {
             const sectionSchema = questionnaire.sections[section.id];
             const validate = ajv.compile(sectionSchema);
             const valid = validate(answers);
+
             if (!valid) {
                 // TODO: Refactor errorhandler to accept a logger and move this in to it
                 logger.error({err: validate.errors}, 'SCHEMA VALIDATION FAILED');
@@ -113,6 +110,8 @@ function createQuestionnaireService(spec) {
                 const validationError = new VError({
                     name: 'JSONSchemaValidationError',
                     info: {
+                        schema: sectionSchema,
+                        answers: rawAnswers,
                         schemaErrors: validate.errors
                     }
                 });


### PR DESCRIPTION
When submitting answers the consumer may get an error object as a response. Include the posted answers and relevant section schema in the error response. This will allow the page to be re-rendered with the appropriate data.