### PR TITLE
Update express openapi validator

### DIFF
--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -373,7 +373,6 @@
                         "description": "The id of the specific questionnaire instance. Format UUIDv4.",
                         "schema": {
                             "type": "string",
-                            "format": "UUIDv4",
                             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                         },
                         "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"
@@ -683,7 +682,6 @@
                         "description": "The id of the specific questionnaire instance. Format UUIDv4.",
                         "schema": {
                             "type": "string",
-                            "format": "UUIDv4",
                             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                         },
                         "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"
@@ -898,7 +896,6 @@
                         "description": "The id of the specific questionnaire instance. Format UUIDv4.",
                         "schema": {
                             "type": "string",
-                            "format": "UUIDv4",
                             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                         },
                         "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"
@@ -1131,7 +1128,6 @@
                         "description": "The id of the specific questionnaire instance. Format UUIDv4.",
                         "schema": {
                             "type": "string",
-                            "format": "UUIDv4",
                             "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                         },
                         "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"
@@ -1463,7 +1459,6 @@
                 "description": "The id of the specific questionnaire instance. Format UUIDv4.",
                 "schema": {
                     "type": "string",
-                    "format": "UUIDv4",
                     "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
                 },
                 "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"

--- a/openapi/src/json-schemas/parameters/questionnaireId.json
+++ b/openapi/src/json-schemas/parameters/questionnaireId.json
@@ -1,6 +1,5 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "string",
-    "format": "UUIDv4",
     "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2636,23 +2636,30 @@
             "integrity": "sha512-cChqAjXe8E3KDe4XbmkpYpk/vQdy4s3n1ccxVgij+2F0rS86hiOQvTrYnHBc1jZstqpGrOzLgHMByh046fKgyQ=="
         },
         "express-openapi-validator": {
-            "version": "0.53.3",
-            "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-0.53.3.tgz",
-            "integrity": "sha512-ryIR25GLSRLmZgHd2uUpQ3vtcGoRmH0Tqwbbw2XFfMvWrOHbSTM1QILidE1b8uG5xISLvo+mJBSJtEf7ZtXT3A==",
+            "version": "git+https://github.com/webstacker/express-openapi-validator.git#826de60058f012a9536f238b482ed12a0be0a5a2",
+            "from": "git+https://github.com/webstacker/express-openapi-validator.git",
             "requires": {
+                "ajv": "^6.10.2",
                 "js-yaml": "^3.13.1",
-                "lodash": "^4.17.11",
-                "multer": "^1.4.1",
+                "lodash": "^4.17.15",
+                "lodash.merge": "^4.6.2",
+                "multer": "^1.4.2",
                 "ono": "^5.0.1",
-                "openapi-request-coercer": "^2.3.0",
-                "openapi-request-validator": "^3.8.1",
-                "openapi-schema-validator": "^3.0.3",
-                "openapi-security-handler": "^2.0.4",
-                "openapi-types": "^1.3.5",
                 "path-to-regexp": "^3.0.0",
                 "ts-log": "^2.1.4"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.10.2",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
+                    "integrity": "sha512-TXtUUEYHuaTEbLZWIKUr5pmBuhDLy+8KYtPYdcV8qC+pOZL+NKqYwvWSRrVXHn+ZmRRAu8vJTAznH7Oag6RVRw==",
+                    "requires": {
+                        "fast-deep-equal": "^2.0.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "ono": {
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.1.tgz",
@@ -5953,9 +5960,9 @@
             }
         },
         "lodash": {
-            "version": "4.17.11",
-            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-            "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+            "version": "4.17.15",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+            "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
         },
         "lodash.includes": {
             "version": "4.3.0",
@@ -6286,9 +6293,9 @@
             "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         },
         "mixin-deep": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
-            "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
+            "version": "1.3.2",
+            "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
+            "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
             "dev": true,
             "requires": {
                 "for-in": "^1.0.2",
@@ -6364,9 +6371,9 @@
             "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "multer": {
-            "version": "1.4.1",
-            "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.1.tgz",
-            "integrity": "sha512-zzOLNRxzszwd+61JFuAo0fxdQfvku12aNJgnla0AQ+hHxFmfc/B7jBVuPr5Rmvu46Jze/iJrFpSOsD7afO8SDw==",
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.2.tgz",
+            "integrity": "sha512-xY8pX7V+ybyUpbYMxtjM9KAiD9ixtg5/JkeKUTD6xilfDv0vzzOFcCp4Ljb1UU3tSOM3VTZtKo63OmzOrGi3Cg==",
             "requires": {
                 "append-field": "^1.0.0",
                 "busboy": "^0.2.11",
@@ -6947,48 +6954,6 @@
                 "format-util": "^1.0.3"
             }
         },
-        "openapi-jsonschema-parameters": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/openapi-jsonschema-parameters/-/openapi-jsonschema-parameters-1.1.1.tgz",
-            "integrity": "sha512-KYcDHQP3Yno8H3pwJzLVvEJ7MAcrBsMzZSFzpyWFz96CqwgHGX+Suj6UbqajpO/LK4owAcal543JR7cMV+eDRw==",
-            "requires": {
-                "openapi-types": "1.3.4"
-            },
-            "dependencies": {
-                "openapi-types": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
-                    "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
-                }
-            }
-        },
-        "openapi-request-coercer": {
-            "version": "2.3.0",
-            "resolved": "https://registry.npmjs.org/openapi-request-coercer/-/openapi-request-coercer-2.3.0.tgz",
-            "integrity": "sha512-oLrxgYOS3CE+ystqeZEBlpxiuQy6Q5HNLMLj9ciMGdJL7x73NedVWkEU00RJ8acjqZJEm73IYMRhQ0D4De14/A==",
-            "requires": {
-                "openapi-types": "1.3.4"
-            },
-            "dependencies": {
-                "openapi-types": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
-                    "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
-                }
-            }
-        },
-        "openapi-request-validator": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/openapi-request-validator/-/openapi-request-validator-3.8.1.tgz",
-            "integrity": "sha512-0qdkWRsz7i18vwjscKoZ5EPabUTJzP3KVx4df01F3eOahMzwI1OHnuhxxEhqDA5rCK9j2HKIQQwLPkZbqRsqjQ==",
-            "requires": {
-                "ajv": "^6.5.4",
-                "content-type": "^1.0.4",
-                "openapi-jsonschema-parameters": "1.1.1",
-                "openapi-types": "1.3.5",
-                "ts-log": "^2.1.4"
-            }
-        },
         "openapi-sampler": {
             "version": "1.0.0-beta.14",
             "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.0.0-beta.14.tgz",
@@ -6997,44 +6962,6 @@
             "requires": {
                 "json-pointer": "^0.6.0"
             }
-        },
-        "openapi-schema-validator": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/openapi-schema-validator/-/openapi-schema-validator-3.0.3.tgz",
-            "integrity": "sha512-KKpeNEvAmpy6B2JCfyrM4yWjL6vggDCVbBoR8Yfkj0Jltc6PCW+dBbcg+1yrTCuDv80qBQJ6w0ejA71DlOFegA==",
-            "requires": {
-                "ajv": "^6.5.2",
-                "lodash.merge": "^4.6.1",
-                "openapi-types": "1.3.4",
-                "swagger-schema-official": "2.0.0-bab6bed"
-            },
-            "dependencies": {
-                "openapi-types": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
-                    "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
-                }
-            }
-        },
-        "openapi-security-handler": {
-            "version": "2.0.4",
-            "resolved": "https://registry.npmjs.org/openapi-security-handler/-/openapi-security-handler-2.0.4.tgz",
-            "integrity": "sha512-blz/UftEqYQLAByuEVITePUI9hV5Rd91CEK8yrsKDUaf3zk6cmIMafJ2qvagHqjXRRtL7fOqvsSKIeFrai+HfQ==",
-            "requires": {
-                "openapi-types": "1.3.4"
-            },
-            "dependencies": {
-                "openapi-types": {
-                    "version": "1.3.4",
-                    "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.4.tgz",
-                    "integrity": "sha512-h8rADpW3k/wepLdERKF0VKMAPdoFYNQCLGPmc/f8sgQ2dxUy+7sY4WAX2XDUDjhKTjbJVbxxofLkzy7f1/tE4g=="
-                }
-            }
-        },
-        "openapi-types": {
-            "version": "1.3.5",
-            "resolved": "https://registry.npmjs.org/openapi-types/-/openapi-types-1.3.5.tgz",
-            "integrity": "sha512-11oi4zYorsgvg5yBarZplAqbpev5HkuVNPlZaPTknPDzAynq+lnJdXAmruGWP0s+dNYZS7bjM+xrTpJw7184Fg=="
         },
         "optimist": {
             "version": "0.6.1",
@@ -8405,9 +8332,9 @@
             "dev": true
         },
         "set-value": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
-            "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
+            "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
             "dev": true,
             "requires": {
                 "extend-shallow": "^2.0.1",
@@ -9079,11 +9006,6 @@
                 "has-flag": "^3.0.0"
             }
         },
-        "swagger-schema-official": {
-            "version": "2.0.0-bab6bed",
-            "resolved": "https://registry.npmjs.org/swagger-schema-official/-/swagger-schema-official-2.0.0-bab6bed.tgz",
-            "integrity": "sha1-cAcEaNbSl3ylI3suUZyn0Gouo/0="
-        },
         "swagger-ui-dist": {
             "version": "3.22.3",
             "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.22.3.tgz",
@@ -9568,38 +9490,15 @@
             }
         },
         "union-value": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
-            "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
+            "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
             "dev": true,
             "requires": {
                 "arr-union": "^3.1.0",
                 "get-value": "^2.0.6",
                 "is-extendable": "^0.1.1",
-                "set-value": "^0.4.3"
-            },
-            "dependencies": {
-                "extend-shallow": {
-                    "version": "2.0.1",
-                    "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
-                    "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-                    "dev": true,
-                    "requires": {
-                        "is-extendable": "^0.1.0"
-                    }
-                },
-                "set-value": {
-                    "version": "0.4.3",
-                    "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
-                    "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-                    "dev": true,
-                    "requires": {
-                        "extend-shallow": "^2.0.1",
-                        "is-extendable": "^0.1.1",
-                        "is-plain-object": "^2.0.1",
-                        "to-object-path": "^0.3.0"
-                    }
-                }
+                "set-value": "^2.0.1"
             }
         },
         "unique-string": {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "express": "~4.16.0",
         "express-jwt": "^5.3.1",
         "express-jwt-authz": "^2.3.1",
-        "express-openapi-validator": "^0.53.3",
+        "express-openapi-validator": "git+https://github.com/webstacker/express-openapi-validator.git",
         "got": "^9.6.0",
         "helmet": "^3.15.0",
         "json-pointer": "^0.6.0",


### PR DESCRIPTION
We were using v0.53 of open api validator which was failing to properly validate querystring values against our openapi schema. Updating to the latest version (1.4.0) had changes in behaviour:

1. If "additionalProperties: false" is set, the new version removes any additional properties prior to validation. This gives false positives causing our tests to fail.
2. Unknown string formats in schemas now throw an error instead of being ignored

To address issue 1 I've forked the module and set "removeAdditional" to false.
To address issue 2 I've removed the unknown format "UUIDv4" from the questionnaireId param schema. It wasn't being used as part of the validation so safe to do so.

All tests are now passing again.