### PR TITLE
Update progress entries to use router

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7633,7 +7633,7 @@
             }
         },
         "q-router": {
-            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-router.git#362fc8e97067447ba6254fee04bdcd6634fc2680",
+            "version": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-router.git#7c4f62088d45018aea74bbeb22c68b4694cece96",
             "from": "git+https://github.com/CriminalInjuriesCompensationAuthority/q-router.git",
             "requires": {
                 "json-rules": "git+https://github.com/webstacker/json-rules.git#b1254856c95c86b4752fee86492595e1780e1d9e",


### PR DESCRIPTION
The progress entries code was bypassing the router logic and causing the backward/forward behaviour to be incorrect. This fixes that issue.