### PR TITLE
Return coerced answers

### DIFF
--- a/middleware/error-handler/index.js
+++ b/middleware/error-handler/index.js
@@ -112,7 +112,7 @@ module.exports = async (err, req, res, next) => {
         error.errors.push(...jsonApiErrors);
         error.meta = {
             schema: errorInfo.schema,
-            answers: errorInfo.answers
+            answers: errorInfo.coercedAnswers
         };
 
         return res.status(400).json(error);

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -282,6 +282,7 @@ function createQuestionnaireService(spec) {
                     info: {
                         schema: sectionSchema,
                         answers: rawAnswers,
+                        coercedAnswers: answers,
                         schemaErrors: validate.errors
                     }
                 });


### PR DESCRIPTION
When posting answers, if a validation error occurred, the DCS would return the request body as it was supplied. This was causing issues with fields that required their type to be coerced e.g.

```{"foo":"true"}``` to ```{"foo":true}```

The DCS now returns the coerced request body.