### PR TITLE
Update OpenAPI validator

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2433,10 +2433,13 @@
             }
         },
         "eslint-utils": {
-            "version": "1.3.1",
-            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
-            "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
-            "dev": true
+            "version": "1.4.2",
+            "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.2.tgz",
+            "integrity": "sha512-eAZS2sEUMlIeCjBeubdj45dmBHQwPHWyBcT1VSYB7o9x9WRRqKxyUoiXlRjyAwzN7YEzHJlYg0NmzDRWx6GP4Q==",
+            "dev": true,
+            "requires": {
+                "eslint-visitor-keys": "^1.0.0"
+            }
         },
         "eslint-visitor-keys": {
             "version": "1.0.0",
@@ -2636,8 +2639,9 @@
             "integrity": "sha512-cChqAjXe8E3KDe4XbmkpYpk/vQdy4s3n1ccxVgij+2F0rS86hiOQvTrYnHBc1jZstqpGrOzLgHMByh046fKgyQ=="
         },
         "express-openapi-validator": {
-            "version": "git+https://github.com/webstacker/express-openapi-validator.git#826de60058f012a9536f238b482ed12a0be0a5a2",
-            "from": "git+https://github.com/webstacker/express-openapi-validator.git",
+            "version": "1.6.2",
+            "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-1.6.2.tgz",
+            "integrity": "sha512-k/oyCDlgSTxwAne52PNHTXLqa6o9fJeATwITo56C+iTkUVPf9LE/GCTMdRUtGsT8j2NkXxW+FBItaqDhuovP1Q==",
             "requires": {
                 "ajv": "^6.10.2",
                 "js-yaml": "^3.13.1",
@@ -2661,9 +2665,9 @@
                     }
                 },
                 "ono": {
-                    "version": "5.0.1",
-                    "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.1.tgz",
-                    "integrity": "sha512-4/4BPGHX8OuDDNx1SrOqTOI7zajPjvBvrG1jDG3hDq4qBpoKlzG2d83Vdz26hvv0FFWYsLdHf+1Vu/k2d8Ww9w=="
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/ono/-/ono-5.0.2.tgz",
+                    "integrity": "sha512-6XDlkEDQCgHNOdWS5SQlCSEJrJ9Ifh6lGrI8llR/UYOOA83EUVCt+4eWo8LT0rvEfyYSYJG90ExJHnTJqsoPBA=="
                 },
                 "path-to-regexp": {
                     "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "express": "~4.16.0",
         "express-jwt": "^5.3.1",
         "express-jwt-authz": "^2.3.1",
-        "express-openapi-validator": "git+https://github.com/webstacker/express-openapi-validator.git",
+        "express-openapi-validator": "^1.6.2",
         "got": "^9.6.0",
         "helmet": "^3.15.0",
         "json-pointer": "^0.6.0",


### PR DESCRIPTION
Uses the package from npm instead of out local fork.