### PR TITLE
Increase replicas

### DIFF
--- a/kube_deploy/Production/deploy.yml
+++ b/kube_deploy/Production/deploy.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: dcs-app-prod
 spec:
-  replicas: 1
+  replicas: 4
   template:
     metadata:
       labels:

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: dcs-app-uat
 spec:
-  replicas: 1
+  replicas: 2
   template:
     metadata:
       labels:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "0.0.1",
+    "version": "0.0.2",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",


### PR DESCRIPTION
Currently our PROD and UAT deployments have replicas set to 1. As per the guidance I have increase these to 4 for PROD:

https://user-guide.cloud-platform.service.justice.gov.uk/documentation/concepts/deploying.html#multiple-replicas

I've set UAT to 2 to ensure we're testing with multiple replicas.