### PR TITLE
Add app version header

### DIFF
--- a/app.js
+++ b/app.js
@@ -76,6 +76,8 @@ app.use('/docs', docsRouter);
 app.use((req, res, next) => {
     // Default to JSON:API content type for all subsequent responses
     res.type('application/vnd.api+json');
+    // https://stackoverflow.com/a/22339262/2952356
+    // `process.env.npm_package_version` only works if you use npm start to run the app.
     res.set('Application-Version', process.env.npm_package_version);
     next();
 });

--- a/app.js
+++ b/app.js
@@ -73,9 +73,10 @@ app.use(express.static(path.join(__dirname, 'public')));
 
 app.use('/docs', docsRouter);
 
-// Default to JSON:API content type for all subsequent responses
 app.use((req, res, next) => {
+    // Default to JSON:API content type for all subsequent responses
     res.type('application/vnd.api+json');
+    res.set('Application-Version', process.env.npm_package_version);
     next();
 });
 


### PR DESCRIPTION
Adds a custom `Application-Version` response header. The value is taken indirectly (via the auto-created environment variables) from the `package.json`