### PR TITLE
R cv1.0.0 typo fix

### DIFF
--- a/questionnaire/templates.js
+++ b/questionnaire/templates.js
@@ -3877,7 +3877,23 @@ module.exports = {
                     on: {
                         ANSWER: [
                             {
-                                target: 'p-gp-enter-your-address'
+                                target: 'p-gp-enter-your-address',
+                                cond: [
+                                    '==',
+                                    '$.answers.p-applicant-are-you-registered-with-gp.q-applicant-are-you-registered-with-gp',
+                                    true
+                                ]
+                            },
+                            {
+                                target: 'p-gp-enter-your-address',
+                                cond: [
+                                    '==',
+                                    '$.answers.p-applicant-have-you-seen-a-gp.q-applicant-have-you-seen-a-gp',
+                                    true
+                                ]
+                            },
+                            {
+                                target: 'p--context-compensation'
                             }
                         ]
                     }

--- a/questionnaire/templates.js
+++ b/questionnaire/templates.js
@@ -2676,7 +2676,7 @@ module.exports = {
                 required: [
                     'q-gp-building-and-street',
                     'q-gp-town-or-city',
-                    'q-gp-building-and-street-2'
+                    'q-gp-building-and-street2'
                 ],
                 additionalProperties: false,
                 properties: {
@@ -2688,7 +2688,7 @@ module.exports = {
                             maxLength: 'Practice name must be less than 60 characters'
                         }
                     },
-                    'q-gp-building-and-street-2': {
+                    'q-gp-building-and-street2': {
                         type: 'string',
                         title: 'Building and street',
                         maxLength: 60,
@@ -2724,14 +2724,14 @@ module.exports = {
                 errorMessage: {
                     required: {
                         'q-gp-building-and-street': "Enter the name of your GP's practice",
-                        'q-gp-building-and-street-2': 'Enter the building and street of your GP',
+                        'q-gp-building-and-street2': 'Enter the building and street of your GP',
                         'q-gp-town-or-city': 'Enter the town or city where you live'
                     }
                 },
                 examples: [
                     {
                         'q-gp-building-and-street': '1 Foo Lane',
-                        'q-gp-building-and-street-2': 'Flat 2/3',
+                        'q-gp-building-and-street2': 'Flat 2/3',
                         'q-gp-town-or-city': 'FooCity',
                         'q-gp-county': 'FooCounty',
                         'q-gp-postcode': 'G1 1XX'
@@ -2740,35 +2740,35 @@ module.exports = {
                 invalidExamples: [
                     {
                         'q-gp-building-and-street': 12345,
-                        'q-gp-building-and-street-2': 'Flat 2/3',
+                        'q-gp-building-and-street2': 'Flat 2/3',
                         'q-gp-town-or-city': 'FooCity',
                         'q-gp-county': 'FooCounty',
                         'q-gp-postcode': 'G1 1XX'
                     },
                     {
                         'q-gp-building-and-street': '1 Foo Lane',
-                        'q-gp-building-and-street-2': 12345,
+                        'q-gp-building-and-street2': 12345,
                         'q-gp-town-or-city': 'FooCity',
                         'q-gp-county': 'FooCounty',
                         'q-gp-postcode': 'G1 1XX'
                     },
                     {
                         'q-gp-building-and-street': '1 Foo Lane',
-                        'q-gp-building-and-street-2': 'Flat 2/3',
+                        'q-gp-building-and-street2': 'Flat 2/3',
                         'q-gp-town-or-city': 12345,
                         'q-gp-county': 'FooCounty',
                         'q-gp-postcode': 'G1 1XX'
                     },
                     {
                         'q-gp-building-and-street': '1 Foo Lane',
-                        'q-gp-building-and-street-2': 'Flat 2/3',
+                        'q-gp-building-and-street2': 'Flat 2/3',
                         'q-gp-town-or-city': 'FooCity',
                         'q-gp-county': 12345,
                         'q-gp-postcode': 'G1 1XX'
                     },
                     {
                         'q-gp-building-and-street': '1 Foo Lane',
-                        'q-gp-building-and-street-2': 'Flat 2/3',
+                        'q-gp-building-and-street2': 'Flat 2/3',
                         'q-gp-town-or-city': 'FooCity',
                         'q-gp-county': 'FooCounty',
                         'q-gp-postcode': 12345


### PR DESCRIPTION
This PR is composed of the following changes:

- GP address line 2 had a typo in the questionId resulting in the PDF being wrong. This has been fixed.
- Routing for the GP questions has changed. If the user answers no to both the "have you seen a GP" and "are you registered with a gp" questions, the applicant now doesn't need to enter an address.

This has been manually tested and passed automated testing.