### PR TITLE
Bump q-router to 2.5.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -535,6 +535,7 @@
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
             "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "2.0.3",
                 "run-parallel": "^1.1.9"
@@ -543,12 +544,14 @@
         "@nodelib/fs.stat": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+            "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+            "dev": true
         },
         "@nodelib/fs.walk": {
             "version": "1.2.4",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
             "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.scandir": "2.1.3",
                 "fastq": "^1.6.0"
@@ -855,53 +858,10 @@
             "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ=="
         },
         "ajv-formats-mobile-uk": {
-            "version": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#865470f8460d975f8924cc83a86b5f216944add6",
-            "from": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#v0.0.1",
+            "version": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#47d59a8103eefc2e15b14d171a5e000110767963",
+            "from": "github:CriminalInjuriesCompensationAuthority/ajv-formats-mobile-uk#v0.1.0",
             "requires": {
-                "google-libphonenumber": "^3.2.7",
-                "q-base-config": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f"
-            },
-            "dependencies": {
-                "detect-newline": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
-                    "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA=="
-                },
-                "globby": {
-                    "version": "11.0.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-                    "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
-                    "requires": {
-                        "array-union": "^2.1.0",
-                        "dir-glob": "^3.0.1",
-                        "fast-glob": "^3.1.1",
-                        "ignore": "^5.1.4",
-                        "merge2": "^1.3.0",
-                        "slash": "^3.0.0"
-                    }
-                },
-                "ignore": {
-                    "version": "5.1.4",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
-                },
-                "module-zero": {
-                    "version": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a",
-                    "from": "github:webstacker/module-zero#v0.6.1",
-                    "requires": {
-                        "detect-newline": "^3.1.0",
-                        "fs-extra": "^8.1.0",
-                        "globby": "^11.0.0",
-                        "write-pkg": "^4.0.0"
-                    }
-                },
-                "q-base-config": {
-                    "version": "github:CriminalInjuriesCompensationAuthority/q-base-config#422966d36b16ac434497b57451e4bc426e70e36f",
-                    "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.6.0",
-                    "requires": {
-                        "module-zero": "github:webstacker/module-zero#22a0fa68b7160fdab0cb2cdf3c266effc11ed39a"
-                    }
-                }
+                "google-libphonenumber": "^3.2.7"
             }
         },
         "ansi-align": {
@@ -1076,7 +1036,8 @@
         "array-union": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+            "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+            "dev": true
         },
         "array-unique": {
             "version": "0.3.2",
@@ -2415,7 +2376,8 @@
         "detect-indent": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-5.0.0.tgz",
-            "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50="
+            "integrity": "sha1-OHHMCmoALow+Wzz38zYmRnXwa50=",
+            "dev": true
         },
         "detect-newline": {
             "version": "2.1.0",
@@ -2442,6 +2404,7 @@
             "version": "3.0.1",
             "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
             "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+            "dev": true,
             "requires": {
                 "path-type": "^4.0.0"
             },
@@ -2449,7 +2412,8 @@
                 "path-type": {
                     "version": "4.0.0",
                     "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+                    "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+                    "dev": true
                 }
             }
         },
@@ -3190,6 +3154,7 @@
             "version": "3.2.2",
             "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
             "integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+            "dev": true,
             "requires": {
                 "@nodelib/fs.stat": "^2.0.2",
                 "@nodelib/fs.walk": "^1.2.3",
@@ -3203,6 +3168,7 @@
                     "version": "3.0.2",
                     "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
                     "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+                    "dev": true,
                     "requires": {
                         "fill-range": "^7.0.1"
                     }
@@ -3211,6 +3177,7 @@
                     "version": "7.0.1",
                     "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
                     "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+                    "dev": true,
                     "requires": {
                         "to-regex-range": "^5.0.1"
                     }
@@ -3218,12 +3185,14 @@
                 "is-number": {
                     "version": "7.0.0",
                     "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+                    "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+                    "dev": true
                 },
                 "micromatch": {
                     "version": "4.0.2",
                     "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
                     "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+                    "dev": true,
                     "requires": {
                         "braces": "^3.0.1",
                         "picomatch": "^2.0.5"
@@ -3233,6 +3202,7 @@
                     "version": "5.0.1",
                     "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
                     "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+                    "dev": true,
                     "requires": {
                         "is-number": "^7.0.0"
                     }
@@ -3279,6 +3249,7 @@
             "version": "1.7.0",
             "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
             "integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+            "dev": true,
             "requires": {
                 "reusify": "^1.0.4"
             }
@@ -3465,6 +3436,7 @@
             "version": "8.1.0",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
             "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.2.0",
                 "jsonfile": "^4.0.0",
@@ -3498,7 +3470,8 @@
                 "ansi-regex": {
                     "version": "2.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "aproba": {
                     "version": "1.2.0",
@@ -3519,12 +3492,14 @@
                 "balanced-match": {
                     "version": "1.0.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "brace-expansion": {
                     "version": "1.1.11",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "balanced-match": "^1.0.0",
                         "concat-map": "0.0.1"
@@ -3539,17 +3514,20 @@
                 "code-point-at": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "concat-map": {
                     "version": "0.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "console-control-strings": {
                     "version": "1.1.0",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "core-util-is": {
                     "version": "1.0.2",
@@ -3666,7 +3644,8 @@
                 "inherits": {
                     "version": "2.0.4",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "ini": {
                     "version": "1.3.5",
@@ -3678,6 +3657,7 @@
                     "version": "1.0.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
                     }
@@ -3692,6 +3672,7 @@
                     "version": "3.0.4",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "brace-expansion": "^1.1.7"
                     }
@@ -3699,12 +3680,14 @@
                 "minimist": {
                     "version": "1.2.5",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "minipass": {
                     "version": "2.9.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "safe-buffer": "^5.1.2",
                         "yallist": "^3.0.0"
@@ -3723,6 +3706,7 @@
                     "version": "0.5.3",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "minimist": "^1.2.5"
                     }
@@ -3784,7 +3768,8 @@
                 "npm-normalize-package-bin": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "npm-packlist": {
                     "version": "1.4.8",
@@ -3812,7 +3797,8 @@
                 "number-is-nan": {
                     "version": "1.0.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "object-assign": {
                     "version": "4.1.1",
@@ -3824,6 +3810,7 @@
                     "version": "1.4.0",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "wrappy": "1"
                     }
@@ -3901,7 +3888,8 @@
                 "safe-buffer": {
                     "version": "5.1.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "safer-buffer": {
                     "version": "2.1.2",
@@ -3937,6 +3925,7 @@
                     "version": "1.0.2",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "code-point-at": "^1.0.0",
                         "is-fullwidth-code-point": "^1.0.0",
@@ -3956,6 +3945,7 @@
                     "version": "3.0.1",
                     "bundled": true,
                     "dev": true,
+                    "optional": true,
                     "requires": {
                         "ansi-regex": "^2.0.0"
                     }
@@ -3999,12 +3989,14 @@
                 "wrappy": {
                     "version": "1.0.2",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 },
                 "yallist": {
                     "version": "3.1.1",
                     "bundled": true,
-                    "dev": true
+                    "dev": true,
+                    "optional": true
                 }
             }
         },
@@ -4084,6 +4076,7 @@
             "version": "5.1.1",
             "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
             "integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+            "dev": true,
             "requires": {
                 "is-glob": "^4.0.1"
             }
@@ -4176,7 +4169,8 @@
         "graceful-fs": {
             "version": "4.2.4",
             "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
-            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw=="
+            "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
+            "dev": true
         },
         "grapheme-splitter": {
             "version": "1.0.4",
@@ -4665,7 +4659,8 @@
         "imurmurhash": {
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
-            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o="
+            "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+            "dev": true
         },
         "indent-string": {
             "version": "4.0.0",
@@ -4912,7 +4907,8 @@
         "is-extglob": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+            "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+            "dev": true
         },
         "is-fullwidth-code-point": {
             "version": "3.0.0",
@@ -4930,6 +4926,7 @@
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
             "integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+            "dev": true,
             "requires": {
                 "is-extglob": "^2.1.1"
             }
@@ -5011,7 +5008,8 @@
         "is-plain-obj": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4="
+            "integrity": "sha1-caUMhCnfync8kqOQpKA7OfzVHT4=",
+            "dev": true
         },
         "is-plain-object": {
             "version": "2.0.4",
@@ -5773,10 +5771,6 @@
                 "foreach": "^2.0.4"
             }
         },
-        "json-rules": {
-            "version": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
-            "from": "git+https://github.com/webstacker/json-rules.git"
-        },
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
@@ -5852,6 +5846,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
             "integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.6"
             }
@@ -6611,6 +6606,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
             "integrity": "sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==",
+            "dev": true,
             "requires": {
                 "pify": "^4.0.1",
                 "semver": "^5.6.0"
@@ -6619,7 +6615,8 @@
                 "pify": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
                 }
             }
         },
@@ -6704,7 +6701,8 @@
         "merge2": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-            "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+            "integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+            "dev": true
         },
         "methods": {
             "version": "1.1.2",
@@ -6841,9 +6839,9 @@
                     "dev": true
                 },
                 "globby": {
-                    "version": "11.0.0",
-                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-                    "integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+                    "version": "11.0.1",
+                    "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+                    "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
                     "dev": true,
                     "requires": {
                         "array-union": "^2.1.0",
@@ -6855,17 +6853,17 @@
                     }
                 },
                 "ignore": {
-                    "version": "5.1.4",
-                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-                    "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+                    "version": "5.1.8",
+                    "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+                    "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
                     "dev": true
                 }
             }
         },
         "moment": {
-            "version": "2.24.0",
-            "resolved": "https://registry.npmjs.org/moment/-/moment-2.24.0.tgz",
-            "integrity": "sha512-bV7f+6l2QigeBBZSM/6yTNq4P2fNpSWj/0e7jQcy87A8e7o2nAfP/34/2ky5Vw4B9S446EtIhodAzkFCcR4dQg=="
+            "version": "2.27.0",
+            "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
+            "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
         },
         "morgan": {
             "version": "1.10.0",
@@ -7958,7 +7956,8 @@
         "picomatch": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+            "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+            "dev": true
         },
         "pify": {
             "version": "2.3.0",
@@ -8245,15 +8244,21 @@
             "from": "github:CriminalInjuriesCompensationAuthority/q-base-config#v0.9.0",
             "dev": true,
             "requires": {
-                "module-zero": "github:webstacker/module-zero#3fd45807112efd797792ad0dcda64cc0d064a262"
+                "module-zero": "github:webstacker/module-zero#v0.8.0"
             }
         },
         "q-router": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-router#5f64e1645797f59c8d9eb672f9f426d0d3dbd27c",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+            "version": "github:CriminalInjuriesCompensationAuthority/q-router#6ec5a28346bd5d3882b421edf0df6fdad137b123",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
             "requires": {
-                "json-rules": "git+https://github.com/webstacker/json-rules.git#794d98f1a42316c4e62c2efe76bcb9be8a2944d7",
+                "json-rules": "github:webstacker/json-rules#v0.3.0",
                 "moment": "^2.24.0"
+            },
+            "dependencies": {
+                "json-rules": {
+                    "version": "github:webstacker/json-rules#ea09a0ae33437b985d20af683577a5a1f31d834a",
+                    "from": "github:webstacker/json-rules#v0.3.0"
+                }
             }
         },
         "qs": {
@@ -8687,7 +8692,8 @@
         "reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+            "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+            "dev": true
         },
         "rimraf": {
             "version": "2.6.3",
@@ -8713,7 +8719,8 @@
         "run-parallel": {
             "version": "1.1.9",
             "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+            "integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+            "dev": true
         },
         "rxjs": {
             "version": "6.5.5",
@@ -8954,7 +8961,8 @@
         "signal-exit": {
             "version": "3.0.3",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+            "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+            "dev": true
         },
         "sisteransi": {
             "version": "1.0.5",
@@ -8965,7 +8973,8 @@
         "slash": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+            "integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==",
+            "dev": true
         },
         "slice-ansi": {
             "version": "2.1.0",
@@ -9118,6 +9127,7 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-2.0.0.tgz",
             "integrity": "sha1-ZYU1WEhh7JfXMNbPQYIuH1ZoQSg=",
+            "dev": true,
             "requires": {
                 "is-plain-obj": "^1.0.0"
             }
@@ -10242,7 +10252,8 @@
         "universalify": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "dev": true
         },
         "unpipe": {
             "version": "1.0.0",
@@ -10646,6 +10657,7 @@
             "version": "3.2.0",
             "resolved": "https://registry.npmjs.org/write-json-file/-/write-json-file-3.2.0.tgz",
             "integrity": "sha512-3xZqT7Byc2uORAatYiP3DHUUAVEkNOswEWNs9H5KXiicRTvzYzYqKjYc4G7p+8pltvAw641lVByKVtMpf+4sYQ==",
+            "dev": true,
             "requires": {
                 "detect-indent": "^5.0.0",
                 "graceful-fs": "^4.1.15",
@@ -10658,12 +10670,14 @@
                 "pify": {
                     "version": "4.0.1",
                     "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="
+                    "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+                    "dev": true
                 },
                 "write-file-atomic": {
                     "version": "2.4.3",
                     "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
                     "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
+                    "dev": true,
                     "requires": {
                         "graceful-fs": "^4.1.11",
                         "imurmurhash": "^0.1.4",
@@ -10676,6 +10690,7 @@
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/write-pkg/-/write-pkg-4.0.0.tgz",
             "integrity": "sha512-v2UQ+50TNf2rNHJ8NyWttfm/EJUBWMJcx6ZTYZr6Qp52uuegWw/lBkCtCbnYZEmPRNL61m+u67dAmGxo+HTULA==",
+            "dev": true,
             "requires": {
                 "sort-keys": "^2.0.0",
                 "type-fest": "^0.4.1",
@@ -10685,7 +10700,8 @@
                 "type-fest": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-                    "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw=="
+                    "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+                    "dev": true
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
         "pg": "^7.11.0",
         "pino": "^5.12.6",
         "pino-http": "^4.2.0",
-        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.4.0",
+        "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.0",
         "swagger-ui-express": "^4.0.2",
         "uuid": "^3.3.2",
         "verror": "^1.10.0"


### PR DESCRIPTION
* Bump q-router to 2.5.0. Allows templates to use answer arrays for routing.

I've left the base branch as "master". This will need changed depending on when this PR is merged