### PR TITLE
Include all files in test coverage report

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -12,6 +12,25 @@ process.env.DCS_LOG_LEVEL = 'silent';
 process.env.NOTIFY_API_KEY = '123apiKey';
 
 config.coverageThreshold = {
+    './!(db)/!(questionnaire-dal).js': {
+        branches: 60,
+        functions: 60,
+        lines: 60,
+        statements: 60
+    },
+    './db/*.js': {
+        branches: 50,
+        functions: 0,
+        lines: 35,
+        statements: 35
+    },
+    './questionnaire/questionnaire-dal.js': {
+        branches: 0,
+        functions: 0,
+        lines: 9,
+        statements: 9
+    },
+
     './*/!(message-bus|notify|request)/**/*.js': {
         statements: 54,
         branches: 60,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "1.3.2",
+    "version": "1.3.3",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",


### PR DESCRIPTION
This adds files to the coverage report that appear one level deep in the directory structure. The current glob incorrectly omitted them.