### PR TITLE
Add resubmission of failed endpoint

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -29,10 +29,10 @@ config.coverageThreshold = {
     './questionnaire/questionnaire-dal.js': {
         branches: 0,
         functions: 0,
-        lines: 9,
-        statements: 9
+        lines: 7,
+        statements: 7
     },
-    './*/!(message-bus|notify|request)/**/*.js': {
+    './*/!(message-bus|notify|request|error-handler)/**/*.js': {
         statements: 54,
         branches: 60,
         functions: 50,
@@ -55,6 +55,12 @@ config.coverageThreshold = {
         branches: 60,
         functions: 0,
         lines: 23
+    },
+    './*/error-handler/**/*.js': {
+        statements: 45,
+        branches: 60,
+        functions: 40,
+        lines: 47
     }
 };
 

--- a/middleware/error-handler/index.js
+++ b/middleware/error-handler/index.js
@@ -141,7 +141,7 @@ module.exports = async (err, req, res, next) => {
             submissions: errorInfo.submissions
         };
 
-        return res.status(200).json(error);
+        return res.status(422).json(error);
     }
 
     if (err.name === 'UpdateNotSuccessful') {
@@ -197,7 +197,7 @@ module.exports = async (err, req, res, next) => {
     if (err.statusCode === 409) {
         error.errors.push({
             status: 409,
-            title: '409 Resource Conflict',
+            title: '409 Conflict',
             detail: err.message
         });
 
@@ -209,7 +209,7 @@ module.exports = async (err, req, res, next) => {
         const errors = errorInfo.errors.map(errorObj => {
             return {
                 status: 409,
-                title: '409 Resource Conflict',
+                title: '409 Conflict',
                 detail: errorObj.message
             };
         });
@@ -219,7 +219,7 @@ module.exports = async (err, req, res, next) => {
             submissions: errorInfo.submissions
         };
 
-        return res.status(200).json(error);
+        return res.status(409).json(error);
     }
 
     if (err.name === 'UnauthorizedError') {

--- a/middleware/error-handler/index.js
+++ b/middleware/error-handler/index.js
@@ -197,11 +197,29 @@ module.exports = async (err, req, res, next) => {
     if (err.statusCode === 409) {
         error.errors.push({
             status: 409,
-            title: '409 Conflict',
+            title: '409 Resource Conflict',
             detail: err.message
         });
 
         return res.status(409).json(error);
+    }
+
+    if (err.name === 'ResourceConflicts') {
+        const errorInfo = VError.info(err);
+        const errors = errorInfo.errors.map(errorObj => {
+            return {
+                status: 409,
+                title: '409 Resource Conflict',
+                detail: errorObj.message
+            };
+        });
+
+        error.errors.push(...errors);
+        error.meta = {
+            submissions: errorInfo.submissions
+        };
+
+        return res.status(200).json(error);
     }
 
     if (err.name === 'UnauthorizedError') {

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -1455,6 +1455,184 @@
                 }
             }
         },
+        "/questionnaires/submissions/resubmit-failed": {
+            "post": {
+                "tags": ["Submissions"],
+                "summary": "Resubmit a failed questionnaire submission",
+                "description": "Restart the submission of a failed questionnaire submission",
+                "operationId": "ResubmitQuestionnaire",
+                "x-scopes": ["update:questionnaires"],
+                "x-requests": {
+                    "401": {
+                        "auth": false
+                    },
+                    "403": {
+                        "x-scopes": ["create:dummy-resource"]
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "additionalProperties": false,
+                                    "required": ["data"],
+                                    "properties": {
+                                        "data": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "additionalProperties": false,
+                                                "required": ["id", "type", "attributes"],
+                                                "properties": {
+                                                    "id": {
+                                                        "type": "string",
+                                                        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                                                    },
+                                                    "type": {
+                                                        "enum": ["submissions"]
+                                                    },
+                                                    "attributes": {
+                                                        "type": "object",
+                                                        "additionalProperties": false,
+                                                        "required": [
+                                                            "questionnaireId",
+                                                            "submitted",
+                                                            "status",
+                                                            "caseReferenceNumber"
+                                                        ],
+                                                        "properties": {
+                                                            "questionnaireId": {
+                                                                "type": "string",
+                                                                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                                                            },
+                                                            "submitted": {
+                                                                "type": "boolean"
+                                                            },
+                                                            "status": {
+                                                                "enum": [
+                                                                    "NOT_STARTED",
+                                                                    "IN_PROGRESS",
+                                                                    "COMPLETED",
+                                                                    "FAILED"
+                                                                ]
+                                                            },
+                                                            "caseReferenceNumber": {
+                                                                "type": "string",
+                                                                "pattern": "^[0-9]{2}\\\\[0-9]{6}$",
+                                                                "nullable": true
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        "meta": {
+                                            "type": "object"
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "data": [
+                                        {
+                                            "id": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                            "type": "submissions",
+                                            "attributes": {
+                                                "questionnaireId": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                                "submitted": true,
+                                                "status": "IN_PROGRESS",
+                                                "caseReferenceNumber": "11\\111111"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Access token is missing or invalid",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [401]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["401 Unauthorized"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 401,
+                                            "detail": "No authorization token was found"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The JWT doesn't permit access to this endpoint",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [403]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["403 Forbidden"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 403,
+                                            "title": "403 Forbidden",
+                                            "detail": "Insufficient scope"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         "/questionnaires/{questionnaireId}/progress-entries": {
             "get": {
                 "tags": ["ProgressEntries"],

--- a/openapi/src/json-schemas/_questionnaires_submissions_resubmit-failed/post/res/201.json
+++ b/openapi/src/json-schemas/_questionnaires_submissions_resubmit-failed/post/res/201.json
@@ -1,0 +1,54 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["data"],
+    "properties": {
+        "data": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "additionalProperties": false,
+                "required": ["id", "type", "attributes"],
+                "properties": {
+                    "id": {
+                        "type": "string",
+                        "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                    },
+                    "type": {
+                        "const": "submissions"
+                    },
+                    "attributes": {
+                        "type": "object",
+                        "additionalProperties": false,
+                        "required": [
+                            "questionnaireId",
+                            "submitted",
+                            "status",
+                            "caseReferenceNumber"
+                        ],
+                        "properties": {
+                            "questionnaireId": {
+                                "type": "string",
+                                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                            },
+                            "submitted": {
+                                "type": "boolean"
+                            },
+                            "status": {
+                                "enum": ["NOT_STARTED", "IN_PROGRESS", "COMPLETED", "FAILED"]
+                            },
+                            "caseReferenceNumber": {
+                                "type": ["string", "null"],
+                                "pattern": "^[0-9]{2}\\\\[0-9]{6}$"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "meta": {
+            "type": "object"
+        }
+    }
+}

--- a/openapi/src/openapi-src.json
+++ b/openapi/src/openapi-src.json
@@ -466,6 +466,55 @@
                 }
             }
         },
+        "/questionnaires/submissions/resubmit-failed": {
+            "post": {
+                "tags": ["Submissions"],
+                "summary": "Resubmit a failed questionnaire submission",
+                "description": "Restart the submission of a failed questionnaire submission",
+                "operationId": "ResubmitQuestionnaire",
+                "x-scopes": ["update:questionnaires"],
+                "x-requests": {
+                    "401": {
+                        "auth": false
+                    },
+                    "403": {
+                        "x-scopes": ["create:dummy-resource"]
+                    }
+                },
+                "responses": {
+                    "201": {
+                        "description": "Created",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$ref": "./json-schemas/_questionnaires_submissions_resubmit-failed/post/res/201.json"
+                                },
+                                "example": {
+                                    "data": [
+                                        {
+                                            "id": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                            "type": "submissions",
+                                            "attributes": {
+                                                "questionnaireId": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                                "submitted": true,
+                                                "status": "IN_PROGRESS",
+                                                "caseReferenceNumber": "11\\111111"
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
+                    }
+                }
+            }
+        },
         "/questionnaires/{questionnaireId}/progress-entries": {
             "get": {
                 "tags": ["ProgressEntries"],

--- a/questionnaire/questionnaire-dal.js
+++ b/questionnaire/questionnaire-dal.js
@@ -125,15 +125,11 @@ function questionnaireDAL(spec) {
             result = await db.query('SELECT id FROM questionnaire WHERE submission_status = $1', [
                 submissionStatus
             ]);
-
-            if (result.rowCount === 0) {
-                result = [];
-            }
         } catch (err) {
             throw err;
         }
 
-        return result.rows.map(x => x.id);
+        return result.rowCount ? result.rows.map(x => x.id) : [];
     }
 
     return Object.freeze({

--- a/questionnaire/questionnaire-dal.js
+++ b/questionnaire/questionnaire-dal.js
@@ -118,12 +118,36 @@ function questionnaireDAL(spec) {
         return result;
     }
 
+    async function getQuestionnaireIdsBySubmissionStatus(submissionStatus) {
+        let result;
+
+        try {
+            result = await db.query('SELECT id FROM questionnaire WHERE submission_status = $1', [
+                submissionStatus
+            ]);
+
+            if (result.rowCount === 0) {
+                throw new VError(
+                    {
+                        name: 'ResourceNotFound'
+                    },
+                    `Questionnaires with submission_status "${submissionStatus}" not found`
+                );
+            }
+        } catch (err) {
+            throw err;
+        }
+
+        return result.rows.map(x => x.id);
+    }
+
     return Object.freeze({
         createQuestionnaire,
         updateQuestionnaire,
         getQuestionnaire,
         getQuestionnaireSubmissionStatus,
-        updateQuestionnaireSubmissionStatus
+        updateQuestionnaireSubmissionStatus,
+        getQuestionnaireIdsBySubmissionStatus
     });
 }
 

--- a/questionnaire/questionnaire-dal.js
+++ b/questionnaire/questionnaire-dal.js
@@ -127,12 +127,7 @@ function questionnaireDAL(spec) {
             ]);
 
             if (result.rowCount === 0) {
-                throw new VError(
-                    {
-                        name: 'ResourceNotFound'
-                    },
-                    `Questionnaires with submission_status "${submissionStatus}" not found`
-                );
+                result = [];
             }
         } catch (err) {
             throw err;

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -652,7 +652,13 @@ function createQuestionnaireService({
 
     async function postSubmissions(submissionStatus) {
         const status = submissionStatus.toUpperCase();
-        const questionnaireIds = await db.getQuestionnaireIdsBySubmissionStatus(status);
+        let questionnaireIds;
+        try {
+            questionnaireIds = await db.getQuestionnaireIdsBySubmissionStatus(status);
+        } catch (err) {
+            // no IDs means there is nothing to submit, so return early.
+            return [];
+        }
 
         const errors = [];
         const promises = questionnaireIds.map(async questionnaireId => {

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -589,14 +589,6 @@ function createQuestionnaireService({
     async function createSubmission(questionnaireId) {
         // 1) get questionnaire instance.
         const questionnaire = await getQuestionnaire(questionnaireId);
-        if (!questionnaire) {
-            throw new VError(
-                {
-                    name: 'ResourceNotFound'
-                },
-                `Questionnaire with questionnaireId "${questionnaireId}" does not exist`
-            );
-        }
 
         // 2) get questionnaire instance's submission status.
         const submissionStatus = await getQuestionnaireSubmissionStatus(questionnaireId);
@@ -652,13 +644,7 @@ function createQuestionnaireService({
 
     async function postSubmissions(submissionStatus) {
         const status = submissionStatus.toUpperCase();
-        let questionnaireIds;
-        try {
-            questionnaireIds = await db.getQuestionnaireIdsBySubmissionStatus(status);
-        } catch (err) {
-            // no IDs means there is nothing to submit, so return early.
-            return [];
-        }
+        const questionnaireIds = await db.getQuestionnaireIdsBySubmissionStatus(status);
 
         const errors = [];
         const promises = questionnaireIds.map(async questionnaireId => {

--- a/questionnaire/questionnaire.test.js
+++ b/questionnaire/questionnaire.test.js
@@ -1,5 +1,14 @@
 'use strict';
 
+/* * ****************************************************************************************** * */
+/* * ****************************************************************************************** * */
+/* *         THIS FILE IS GENERATED. ALL MANUAL EDITS MADE TO THIS FILE WILL BE LOST!!!         * */
+/* *         --------------------------------------------------------------------------         * */
+/* *         If you need to make a change to this test file you will need to edit the           * */
+/* *         generate-tests file and regenerate the tests using command line.                   * */
+/* * ****************************************************************************************** * */
+/* * ****************************************************************************************** * */
+
 const VError = require('verror');
 const request = require('supertest');
 const {matchersWithOptions} = require('jest-json-schema');
@@ -63,7 +72,8 @@ jest.doMock('./questionnaire-dal.js', () =>
         },
         updateQuestionnaireSubmissionStatus: () => undefined,
         createQuestionnaireSubmission: () => true,
-        retrieveCaseReferenceNumber: () => '12345678'
+        retrieveCaseReferenceNumber: () => '12345678',
+        getQuestionnaireIdsBySubmissionStatus: () => ['285cb104-0c15-4a9c-9840-cb1007f098fb']
     }))
 );
 
@@ -293,6 +303,7 @@ describe('/questionnaires/{questionnaireId}/sections/{sectionId}/answers', () =>
                     .set('Authorization', `Bearer ${tokens['create:system-answers']}`)
                     .set('Content-Type', 'application/vnd.api+json')
                     .send({data: {type: 'answers', attributes: {'case-reference': '11\\111111'}}});
+
                 expect(res.statusCode).toBe(201);
                 expect(res.type).toBe('application/vnd.api+json');
                 expect(res.body).toMatchSchema({
@@ -949,6 +960,133 @@ describe('/questionnaires/{questionnaireId}/submissions', () => {
                                 properties: {
                                     status: {const: 404},
                                     title: {const: '404 Not Found'},
+                                    detail: {type: 'string'}
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+        });
+    });
+});
+describe('/questionnaires/submissions/resubmit-failed', () => {
+    describe('post', () => {
+        describe('201', () => {
+            it('should Created', async () => {
+                const res = await request(app)
+                    .post('/api/v1/questionnaires/submissions/resubmit-failed')
+                    .set('Authorization', `Bearer ${tokens['update:questionnaires']}`);
+
+                expect(res.statusCode).toBe(201);
+                expect(res.type).toBe('application/vnd.api+json');
+                expect(res.body).toMatchSchema({
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    type: 'object',
+                    additionalProperties: false,
+                    required: ['data'],
+                    properties: {
+                        data: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                additionalProperties: false,
+                                required: ['id', 'type', 'attributes'],
+                                properties: {
+                                    id: {
+                                        type: 'string',
+                                        pattern:
+                                            '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+                                    },
+                                    type: {const: 'submissions'},
+                                    attributes: {
+                                        type: 'object',
+                                        additionalProperties: false,
+                                        required: [
+                                            'questionnaireId',
+                                            'submitted',
+                                            'status',
+                                            'caseReferenceNumber'
+                                        ],
+                                        properties: {
+                                            questionnaireId: {
+                                                type: 'string',
+                                                pattern:
+                                                    '^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$'
+                                            },
+                                            submitted: {type: 'boolean'},
+                                            status: {
+                                                enum: [
+                                                    'NOT_STARTED',
+                                                    'IN_PROGRESS',
+                                                    'COMPLETED',
+                                                    'FAILED'
+                                                ]
+                                            },
+                                            caseReferenceNumber: {
+                                                type: ['string', 'null'],
+                                                pattern: '^[0-9]{2}\\\\[0-9]{6}$'
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        },
+                        meta: {type: 'object'}
+                    }
+                });
+            });
+        });
+        describe('401', () => {
+            it('should Access token is missing or invalid', async () => {
+                const res = await request(app).post(
+                    '/api/v1/questionnaires/submissions/resubmit-failed'
+                );
+
+                expect(res.statusCode).toBe(401);
+                expect(res.type).toBe('application/vnd.api+json');
+                expect(res.body).toMatchSchema({
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    type: 'object',
+                    required: ['errors'],
+                    properties: {
+                        errors: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                required: ['status', 'title', 'detail'],
+                                properties: {
+                                    status: {const: 401},
+                                    title: {const: '401 Unauthorized'},
+                                    detail: {type: 'string'}
+                                }
+                            }
+                        }
+                    }
+                });
+            });
+        });
+        describe('403', () => {
+            it("should The JWT doesn't permit access to this endpoint", async () => {
+                const res = await request(app)
+                    .post('/api/v1/questionnaires/submissions/resubmit-failed')
+                    .set('Authorization', `Bearer ${tokens['create:dummy-resource']}`);
+
+                expect(res.statusCode).toBe(403);
+                expect(res.type).toBe('application/vnd.api+json');
+                expect(res.body).toMatchSchema({
+                    $schema: 'http://json-schema.org/draft-07/schema#',
+                    type: 'object',
+                    required: ['errors'],
+                    properties: {
+                        errors: {
+                            type: 'array',
+                            items: {
+                                type: 'object',
+                                required: ['status', 'title', 'detail'],
+                                properties: {
+                                    status: {const: 403},
+                                    title: {const: '403 Forbidden'},
                                     detail: {type: 'string'}
                                 }
                             }

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -136,9 +136,11 @@ router
                 throw err;
             }
 
-            const response = await questionnaireService.getSubmissionResponseData(questionnaireId);
+            const resource = await questionnaireService.getSubmissionResource(questionnaireId);
 
-            res.status(200).json(response);
+            res.status(200).json({
+                data: resource
+            });
         } catch (err) {
             next(err);
         }
@@ -147,64 +149,27 @@ router
         try {
             const {questionnaireId} = req.params;
             const questionnaireService = createQuestionnaireService({logger: req.log});
-            const questionnaire = await questionnaireService.getQuestionnaire(questionnaireId);
 
-            if (!questionnaire) {
-                const err = Error(
-                    `Questionnaire with questionnaireId "${questionnaireId}" does not exist`
-                );
-                err.name = 'HTTPError';
-                err.statusCode = 404;
-                err.error = '404 Not Found';
-                throw err;
-            }
+            const resource = await questionnaireService.createSubmission(questionnaireId);
 
-            const submissionStatus = await questionnaireService.getQuestionnaireSubmissionStatus(
-                questionnaireId
-            );
-            // are we currently, or have we been on this questionnaire's summary page?
-            // we infer a questionnaire is complete if the user has visited the summary page.
-            const isQuestionnaireComplete = questionnaire.progress.includes(
-                questionnaire.routes.summary
-            );
+            res.status(201).json({
+                data: resource
+            });
+        } catch (err) {
+            next(err);
+        }
+    });
 
-            // if the summary section ID is in the progress array, then that means
-            // the questionnaire is submittable.
-            if (!isQuestionnaireComplete) {
-                const err = Error(
-                    `Questionnaire with ID "${questionnaireId}" is not in a submittable state`
-                );
-                err.name = 'HTTPError';
-                err.statusCode = 409;
-                err.error = '409 Conflict';
-                throw err;
-            }
+router
+    .route('/submissions/resubmit-failed')
+    .post(permissions('update:questionnaires'), async (req, res, next) => {
+        try {
+            const questionnaireService = createQuestionnaireService({logger: req.log});
+            const resource = await questionnaireService.postSubmissions('failed');
 
-            // if the submission status is anything other than 'NOT_STARTED' then it
-            // means that the submission resource has been previously created.
-            // also skip over this for failed application so they can be resubmitted.
-            if (!['NOT_STARTED', 'FAILED'].includes(submissionStatus)) {
-                const err = Error(
-                    `Submission resource with ID "${questionnaireId}" already exists`
-                );
-                err.name = 'HTTPError';
-                err.statusCode = 409;
-                err.error = '409 Conflict';
-                throw err;
-            }
-
-            // check all answers are correct.
-            await questionnaireService.validateAllAnswers(questionnaireId);
-
-            // TODO: refactor `getSubmissionResponseData` to be more intuitive.
-            const response = await questionnaireService.getSubmissionResponseData(
-                questionnaireId,
-                true
-            );
-
-            questionnaireService.createAnswers(questionnaireId, questionnaire.routes.summary, {});
-
-            res.status(201).json(response);
+            res.status(201).json({
+                data: resource
+            });
         } catch (err) {
             next(err);
         }

--- a/questionnaire/submissions.test.js
+++ b/questionnaire/submissions.test.js
@@ -79,7 +79,8 @@ const questionnaireService = createQuestionnaireService({
                 `Questionnaires with submission_status "${submissionStatus}" not found`
             );
         },
-        updateQuestionnaireSubmissionStatus: () => undefined
+        updateQuestionnaireSubmissionStatus: () => undefined,
+        updateQuestionnaire: () => undefined
     })
 });
 


### PR DESCRIPTION
* Add `"/questionnaires/submissions/resubmit-failed"` endpoint.
* Add `getQuestionnaireIdsBySubmissionStatus` DAL function.
* Add `ResourceConflicts` error to cater for submission resource errors that are thrown.
* Rename `getSubmissionResponseData` to `getSubmissionResource`.
* Update tests to actually test the submission functionality directly.
* Update Jest config to allow tests through.

Manually tested using Postman to hit the new endpoint. Emulated `FAILED` submission via row updates using PG Admin.