### PR TITLE
Add common schemas

### DIFF
--- a/openapi/src/json-schemas/api/json-api-base-document.json
+++ b/openapi/src/json-schemas/api/json-api-base-document.json
@@ -1,0 +1,28 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Loosely describes the JSON:API document format",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["data"],
+    "properties": {
+        "data": {
+            "anyOf": [
+                {
+                    "type": "object"
+                },
+                {
+                    "type": "array"
+                }
+            ]
+        },
+        "included": {
+            "type": "array"
+        },
+        "links": {
+            "type": "object"
+        },
+        "meta": {
+            "type": "object"
+        }
+    }
+}

--- a/openapi/src/json-schemas/api/json-api-base-resource.json
+++ b/openapi/src/json-schemas/api/json-api-base-resource.json
@@ -1,0 +1,27 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Loosely describes the JSON:API resource format",
+    "type": "object",
+    "additionalProperties": false,
+    "required": ["type", "id", "attributes"],
+    "properties": {
+        "type": {
+            "type": "string"
+        },
+        "id": {
+            "type": "string",
+            "anyOf": [
+                {"$ref": "../models/definitions/section-id.json"},
+                {"$ref": "../models/definitions/uuid-v4.json"},
+                {"const": "0", "description": "Used by dataset endpoint"}
+            ]
+        },
+        "attributes": {
+            "type": "object",
+            "title": "Any valid resource"
+        },
+        "relationships": {
+            "type": "object"
+        }
+    }
+}

--- a/openapi/src/json-schemas/models/definitions/question-id.json
+++ b/openapi/src/json-schemas/models/definitions/question-id.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Question Id",
+    "type": "string",
+    "pattern": "^q(?:-[a-z0-9]{1,20}){1,20}$"
+}

--- a/openapi/src/json-schemas/models/definitions/questionnaire-template-name.json
+++ b/openapi/src/json-schemas/models/definitions/questionnaire-template-name.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Questionnaire template name",
+    "type": "string",
+    "pattern": "^[a-z]{1,20}(?:-[a-z]{1,20}){0,10}$"
+}

--- a/openapi/src/json-schemas/models/definitions/section-id.json
+++ b/openapi/src/json-schemas/models/definitions/section-id.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Section Id",
+    "type": "string",
+    "pattern": "^(?:p-?(?:-[a-z0-9]{1,20}){1,20}|system|referrer)$"
+}

--- a/openapi/src/json-schemas/models/definitions/semver.json
+++ b/openapi/src/json-schemas/models/definitions/semver.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "semver",
+    "type": "string",
+    "pattern": "^[0-9]{1,3}\\.[0-9]{1,3}\\.[0-9]{1,3}$"
+}

--- a/openapi/src/json-schemas/models/definitions/uuid-v4.json
+++ b/openapi/src/json-schemas/models/definitions/uuid-v4.json
@@ -1,0 +1,6 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "UUID v4",
+    "type": "string",
+    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+}

--- a/openapi/src/json-schemas/models/questionnaire-instance.json
+++ b/openapi/src/json-schemas/models/questionnaire-instance.json
@@ -1,0 +1,110 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "title": "Questionnaire template schema",
+    "required": ["id", "type", "version", "sections", "routes", "answers", "progress", "meta"],
+    "additionalProperties": false,
+    "properties": {
+        "id": {
+            "$ref": "definitions/uuid-v4.json"
+        },
+        "meta": {
+            "type": "object",
+            "required": ["questionnaireDocumentVersion"],
+            "properties": {
+                "questionnaireDocumentVersion": {
+                    "enum": ["1.0.0"]
+                }
+            }
+        },
+        "type": {
+            "$ref": "definitions/questionnaire-template-name.json"
+        },
+        "version": {
+            "$ref": "definitions/semver.json"
+        },
+        "sections": {
+            "type": "object",
+            "additionalProperties": {
+                "$ref": "section.json"
+            }
+        },
+        "routes": {
+            "type": "object",
+            "required": ["initial", "referrer", "summary", "confirmation", "states"],
+            "properties": {
+                "initial": {
+                    "$ref": "definitions/section-id.json"
+                },
+                "referrer": {
+                    "type": "string",
+                    "format": "uri",
+                    "pattern": "^https://"
+                },
+                "summary": {
+                    "$ref": "definitions/section-id.json"
+                },
+                "confirmation": {
+                    "$ref": "definitions/section-id.json"
+                },
+                "states": {
+                    "type": "object",
+                    "additionalProperties": {
+                        "type": "object",
+                        "oneOf": [
+                            {
+                                "additionalProperties": false,
+                                "required": ["type"],
+                                "properties": {
+                                    "type": {
+                                        "const": "final"
+                                    }
+                                }
+                            },
+                            {
+                                "additionalProperties": false,
+                                "required": ["on"],
+                                "properties": {
+                                    "on": {
+                                        "type": "object",
+                                        "required": ["ANSWER"],
+                                        "properties": {
+                                            "ANSWER": {
+                                                "type": "array",
+                                                "minItems": 1,
+                                                "items": {
+                                                    "type": "object",
+                                                    "required": ["target"],
+                                                    "properties": {
+                                                        "target": {
+                                                            "type": "string",
+                                                            "pattern": "^(?:p-?(?:-[a-z0-9]{1,20}){1,20}|system)$"
+                                                        },
+                                                        "cond": {
+                                                            "type": "array",
+                                                            "minItems": 1
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+        "answers": {
+            "type": "object"
+        },
+        "progress": {
+            "type": "array",
+            "minItems": 1,
+            "items": {
+                "$ref": "definitions/section-id.json"
+            }
+        }
+    }
+}

--- a/openapi/src/json-schemas/models/questionnaire-instance.json
+++ b/openapi/src/json-schemas/models/questionnaire-instance.json
@@ -1,7 +1,7 @@
 {
     "$schema": "http://json-schema.org/draft-07/schema#",
     "type": "object",
-    "title": "Questionnaire template schema",
+    "title": "Questionnaire instance schema",
     "required": ["id", "type", "version", "sections", "routes", "answers", "progress", "meta"],
     "additionalProperties": false,
     "properties": {
@@ -77,8 +77,7 @@
                                                     "required": ["target"],
                                                     "properties": {
                                                         "target": {
-                                                            "type": "string",
-                                                            "pattern": "^(?:p-?(?:-[a-z0-9]{1,20}){1,20}|system)$"
+                                                            "$ref": "definitions/section-id.json"
                                                         },
                                                         "cond": {
                                                             "type": "array",

--- a/openapi/src/json-schemas/models/section.json
+++ b/openapi/src/json-schemas/models/section.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Section",
+    "type": "object",
+    "required": ["$schema"],
+    "properties": {
+        "$schema": {
+            "enum": ["http://json-schema.org/draft-07/schema#"]
+        }
+    }
+}


### PR DESCRIPTION
Adds schemas common to all req/res. Aligns the OpenAPI schemas with `q-schema`. These are not a 1-to-1 mapping due to OpenAPI v3.0.1's reduced schema vocabulary. 