### PR TITLE
Add resubmission function

### DIFF
--- a/app.js
+++ b/app.js
@@ -9,6 +9,7 @@ const pino = require('pino-http');
 const errorHandler = require('./middleware/error-handler');
 const docsRouter = require('./docs/routes');
 const questionnaireRouter = require('./questionnaire/routes');
+const submissionsRouter = require('./questionnaire/submissions-routes');
 
 const app = express();
 const logger = pino({
@@ -81,6 +82,8 @@ app.use((req, res, next) => {
     res.set('Application-Version', process.env.npm_package_version);
     next();
 });
+
+app.use('/api/v1/submissions', submissionsRouter);
 
 // Install the OpenApiValidator onto express app
 new OpenApiValidator({

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "2.0.3",
+    "version": "2.1.0",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",

--- a/questionnaire/questionnaire-dal.js
+++ b/questionnaire/questionnaire-dal.js
@@ -118,12 +118,27 @@ function questionnaireDAL(spec) {
         return result;
     }
 
+    async function getQuestionnaireIdsBySubmissionStatus(submissionStatus) {
+        let result;
+
+        try {
+            result = await db.query('SELECT id FROM questionnaire WHERE submission_status = $1', [
+                submissionStatus
+            ]);
+        } catch (err) {
+            throw err;
+        }
+
+        return result.rowCount ? result.rows.map(x => x.id) : [];
+    }
+
     return Object.freeze({
         createQuestionnaire,
         updateQuestionnaire,
         getQuestionnaire,
         getQuestionnaireSubmissionStatus,
-        updateQuestionnaireSubmissionStatus
+        updateQuestionnaireSubmissionStatus,
+        getQuestionnaireIdsBySubmissionStatus
     });
 }
 

--- a/questionnaire/questionnaire-dal.test.js
+++ b/questionnaire/questionnaire-dal.test.js
@@ -1,0 +1,56 @@
+'use strict';
+
+jest.doMock('../db/index.js', () => () => ({
+    query: (query, parameters) => {
+        if (query === 'SELECT id FROM questionnaire WHERE submission_status = $1') {
+            if (parameters.includes('FAILED')) {
+                return {
+                    rowCount: 4,
+                    rows: [
+                        {
+                            id: '4ddb0208-f7da-4237-a244-34e7e58d2ddf'
+                        },
+                        {
+                            id: '95118e91-8ed9-4b41-a7a8-727a353f2d18'
+                        },
+                        {
+                            id: 'be567065-d11c-4ba1-8c3f-147290c7036f'
+                        },
+                        {
+                            id: '93259f6d-1826-4e97-ba39-53b4e232dd81'
+                        }
+                    ]
+                };
+            }
+            if (parameters.includes('FAILED2')) {
+                return {
+                    rowCount: 0
+                };
+            }
+        }
+        return [];
+    }
+}));
+
+const createQuestionnaireDAL = require('./questionnaire-dal');
+
+describe('questionnaire data access layer', () => {
+    describe('getQuestionnaireIdsBySubmissionStatus', () => {
+        it('should get an array of ids for failed submissions', async () => {
+            const questionnaireDAL = createQuestionnaireDAL({logger: jest.fn()});
+            const result = await questionnaireDAL.getQuestionnaireIdsBySubmissionStatus('FAILED');
+            expect(result).toEqual([
+                '4ddb0208-f7da-4237-a244-34e7e58d2ddf',
+                '95118e91-8ed9-4b41-a7a8-727a353f2d18',
+                'be567065-d11c-4ba1-8c3f-147290c7036f',
+                '93259f6d-1826-4e97-ba39-53b4e232dd81'
+            ]);
+        });
+        it('should get an empty array for failed submissions', async () => {
+            const questionnaireDAL = createQuestionnaireDAL({logger: jest.fn()});
+            const result = await questionnaireDAL.getQuestionnaireIdsBySubmissionStatus('FAILED2');
+            expect(result).toEqual([]);
+            expect(result.length).toBe(0);
+        });
+    });
+});

--- a/questionnaire/submissions-routes.js
+++ b/questionnaire/submissions-routes.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const express = require('express');
+const validateJWT = require('express-jwt');
+
+const createSubmissionsService = require('./submissions-service');
+const permissions = require('../middleware/route-permissions');
+
+const router = express.Router();
+
+router.use(validateJWT({secret: process.env.DCS_JWT_SECRET}));
+
+router
+    .route('/resubmit-failed')
+    .post(permissions('update:questionnaires'), async (req, res, next) => {
+        let response;
+        try {
+            const submissionsService = createSubmissionsService({logger: req.log});
+            response = await submissionsService.postFailedSubmissions();
+        } catch (err) {
+            next(err);
+        }
+        res.status(200).json(response);
+    });
+
+module.exports = router;

--- a/questionnaire/submissions-service.js
+++ b/questionnaire/submissions-service.js
@@ -1,0 +1,41 @@
+'use strict';
+
+const createMessageBusCaller = require('../services/message-bus');
+const createQuestionnaireDAL = require('./questionnaire-dal');
+
+function createSubmissionService({logger}) {
+    const db = createQuestionnaireDAL({logger});
+
+    async function getQuestionnaireIdsBySubmissionStatus(status) {
+        return db.getQuestionnaireIdsBySubmissionStatus(status);
+    }
+
+    async function updateQuestionnaireSubmissionStatus(questionnaireId, submissionStatus) {
+        return db.updateQuestionnaireSubmissionStatus(questionnaireId, submissionStatus);
+    }
+
+    async function postFailedSubmissions() {
+        const questionnaireIds = await getQuestionnaireIdsBySubmissionStatus('FAILED');
+        const messageBusCaller = createMessageBusCaller({logger});
+        const promises = questionnaireIds.map(async id => {
+            await updateQuestionnaireSubmissionStatus(id, 'IN_PROGRESS');
+            try {
+                await messageBusCaller.post('SubmissionQueue', {
+                    applicationId: id
+                });
+                return {id, resubmitted: true};
+            } catch (err) {
+                await updateQuestionnaireSubmissionStatus(id, 'FAILED');
+                return {id, resubmitted: false};
+            }
+        });
+        const results = await Promise.all(promises);
+        return results;
+    }
+
+    return Object.freeze({
+        postFailedSubmissions
+    });
+}
+
+module.exports = createSubmissionService;


### PR DESCRIPTION
* Add `/api/v1/submissions/resubmit-failed` endpoint.
* Add `getQuestionnaireIdsBySubmissionStatus` DAL function.
* Add tests

Tests pass.

Manually tested using Postman to hit the new endpoint. Emulated `FAILED` submission via row updates using PG Admin.