### PR TITLE
Move Slack Messaging service to catch block

### DIFF
--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -117,18 +117,20 @@ function createQuestionnaireService({
                 !submissionResponse.body ||
                 submissionResponse.body !== 'Message sent'
             ) {
-                await updateQuestionnaireSubmissionStatus(questionnaireId, 'FAILED');
-                const slackService = createSlackService();
-                slackService.sendMessage({
-                    appReference: `${process.env.APP_ENV || 'dev'}.reporter.webhook`,
-                    messageBodyId: 'message-bus-down',
-                    templateParameters: {
-                        timeStamp: new Date().getTime()
-                    }
-                });
+                throw new VError(
+                    `Questionnaire with id "${questionnaireId}" was not successfully added to the Message Bus queue`
+                );
             }
         } catch (err) {
             await updateQuestionnaireSubmissionStatus(questionnaireId, 'FAILED');
+            const slackService = createSlackService();
+            slackService.sendMessage({
+                appReference: `${process.env.APP_ENV || 'dev'}.reporter.webhook`,
+                messageBodyId: 'message-bus-down',
+                templateParameters: {
+                    timeStamp: new Date().getTime()
+                }
+            });
         }
     }
 


### PR DESCRIPTION
The Slack Service `sendMessage` function was not called when there was a communication issue between DCS and the MB. This change now catches all request errors and invokes the Slack Service's `sendMessage` accordingly.