### PR TITLE
Refactor dataset resource

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,10 +27,10 @@ config.coverageThreshold = {
         statements: 35
     },
     './questionnaire/questionnaire-dal.js': {
-        branches: 0,
-        functions: 0,
-        lines: 9,
-        statements: 9
+        branches: 20,
+        functions: 37,
+        lines: 24,
+        statements: 26
     },
     './*/!(message-bus|request)/**/*.js': {
         statements: 54,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "3.0.5",
+    "version": "3.0.6",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",

--- a/questionnaire/dataset/dataset-routes.js
+++ b/questionnaire/dataset/dataset-routes.js
@@ -1,0 +1,26 @@
+'use strict';
+
+const express = require('express');
+
+const permissions = require('../../middleware/route-permissions');
+const createDatasetService = require('./dataset-service');
+
+const router = express.Router();
+
+router
+    .route('/:questionnaireId/dataset')
+    .get(permissions('read:questionnaires', 'read:answers'), async (req, res, next) => {
+        try {
+            const {questionnaireId} = req.params;
+            const datasetService = createDatasetService({logger: req.log});
+            const resourceCollection = await datasetService.getResource(questionnaireId);
+
+            res.status(200).json({
+                data: resourceCollection
+            });
+        } catch (err) {
+            next(err);
+        }
+    });
+
+module.exports = router;

--- a/questionnaire/dataset/dataset-service.js
+++ b/questionnaire/dataset/dataset-service.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const VError = require('verror');
+
+const defaults = {};
+defaults.createQuestionnaireDAL = require('../questionnaire-dal');
+
+function createDatasetService({
+    logger,
+    createQuestionnaireDAL = defaults.createQuestionnaireDAL
+} = {}) {
+    const db = createQuestionnaireDAL({logger});
+
+    async function getResource(questionnaireId) {
+        const questionnaire = await db.getQuestionnaire(questionnaireId);
+        const dataset = new Map();
+
+        questionnaire.progress.forEach(sectionId => {
+            const sectionAnswers = questionnaire.answers[sectionId];
+
+            if (sectionAnswers) {
+                Object.keys(sectionAnswers).forEach(questionId => {
+                    const answer = sectionAnswers[questionId];
+
+                    if (dataset.has(questionId)) {
+                        const existingAnswer = dataset.get(questionId);
+
+                        // Answers for a specific question id can be collected over multiple sections.
+                        // If previous answers have already be processed for an id, use an appropriate
+                        // merge strategy for the given data type e.g. push to an array, concatenate strings with a delimiter
+                        // ONLY SUPPORTS ARRAYS AT THE MOMENT
+                        if (Array.isArray(existingAnswer)) {
+                            // Ensure answers are of the same type
+                            if (Array.isArray(answer)) {
+                                existingAnswer.push(...answer);
+                            } else {
+                                throw new VError(
+                                    `Question id "${questionId}" found more than once with different answer types. Unable to combine type "array" with "${typeof answer}"`
+                                );
+                            }
+                        } else {
+                            throw new VError(
+                                `Question id "${questionId}" found more than once with unsupported type "${typeof existingAnswer}". Only arrays can be used to combine answers for a single id`
+                            );
+                        }
+                    } else {
+                        dataset.set(questionId, answer);
+                    }
+                });
+            }
+        });
+
+        return [
+            {
+                type: 'dataset',
+                id: 0,
+                attributes: Object.fromEntries(dataset)
+            }
+        ];
+    }
+
+    return Object.freeze({
+        getResource
+    });
+}
+
+module.exports = createDatasetService;

--- a/questionnaire/dataset/dataset-service.test.js
+++ b/questionnaire/dataset/dataset-service.test.js
@@ -1,6 +1,6 @@
 'use strict';
 
-const createQuestionnaireService = require('./questionnaire-service');
+const createDatasetService = require('./dataset-service');
 
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
 function escapeRegExp(string) {
@@ -13,7 +13,7 @@ function errorMessageToRegExp(errorMessage) {
 
 describe('Dataset resource', () => {
     it('should return a dataset resource', async () => {
-        const questionnaireService = createQuestionnaireService({
+        const datasetService = createDatasetService({
             logger: () => 'Logged from dataset test',
             createQuestionnaireDAL: () => ({
                 getQuestionnaire: () => ({
@@ -39,7 +39,7 @@ describe('Dataset resource', () => {
             })
         });
 
-        const dataset = await questionnaireService.getDataset();
+        const dataset = await datasetService.getResource();
 
         expect(dataset[0]).toEqual({
             type: 'dataset',
@@ -56,7 +56,7 @@ describe('Dataset resource', () => {
 
     describe('Given multiple sections with the same question id', () => {
         it('should combine answers agaist a single id instance', async () => {
-            const questionnaireService = createQuestionnaireService({
+            const datasetService = createDatasetService({
                 logger: () => 'Logged from dataset test',
                 createQuestionnaireDAL: () => ({
                     getQuestionnaire: () => ({
@@ -82,7 +82,7 @@ describe('Dataset resource', () => {
                 })
             });
 
-            const dataset = await questionnaireService.getDataset();
+            const dataset = await datasetService.getResource();
 
             expect(dataset[0]).toEqual({
                 type: 'dataset',
@@ -96,7 +96,7 @@ describe('Dataset resource', () => {
         });
 
         it('should throw if the answers to be combined are of different types', async () => {
-            const questionnaireService = createQuestionnaireService({
+            const datasetService = createDatasetService({
                 logger: () => 'Logged from dataset test',
                 createQuestionnaireDAL: () => ({
                     getQuestionnaire: () => ({
@@ -123,11 +123,11 @@ describe('Dataset resource', () => {
                 `Question id "bar" found more than once with different answer types. Unable to combine type "array" with "string"`
             );
 
-            await expect(questionnaireService.getDataset()).rejects.toThrow(rxExpectedError);
+            await expect(datasetService.getResource()).rejects.toThrow(rxExpectedError);
         });
 
         it('should throw if the answers to be combined are not arrays', async () => {
-            const questionnaireService = createQuestionnaireService({
+            const datasetService = createDatasetService({
                 logger: () => 'Logged from dataset test',
                 createQuestionnaireDAL: () => ({
                     getQuestionnaire: () => ({
@@ -154,7 +154,7 @@ describe('Dataset resource', () => {
                 `Question id "bar" found more than once with unsupported type "string". Only arrays can be used to combine answers for a single id`
             );
 
-            await expect(questionnaireService.getDataset()).rejects.toThrow(rxExpectedError);
+            await expect(datasetService.getResource()).rejects.toThrow(rxExpectedError);
         });
     });
 });

--- a/questionnaire/questionnaire-service.js
+++ b/questionnaire/questionnaire-service.js
@@ -247,54 +247,6 @@ function createQuestionnaireService({
         return resourceCollection;
     }
 
-    async function getDataset(questionnaireId) {
-        const questionnaire = await getQuestionnaire(questionnaireId);
-        const dataset = new Map();
-
-        questionnaire.progress.forEach(sectionId => {
-            const sectionAnswers = questionnaire.answers[sectionId];
-
-            if (sectionAnswers) {
-                Object.keys(sectionAnswers).forEach(questionId => {
-                    const answer = sectionAnswers[questionId];
-
-                    if (dataset.has(questionId)) {
-                        const existingAnswer = dataset.get(questionId);
-
-                        // Answers for a specific question id can be collected over multiple sections.
-                        // If previous answers have already be processed for an id, use an appropriate
-                        // merge strategy for the given data type e.g. push to an array, concatenate strings with a delimiter
-                        // ONLY SUPPORTS ARRAYS AT THE MOMENT
-                        if (Array.isArray(existingAnswer)) {
-                            // Ensure answers are of the same type
-                            if (Array.isArray(answer)) {
-                                existingAnswer.push(...answer);
-                            } else {
-                                throw new VError(
-                                    `Question id "${questionId}" found more than once with different answer types. Unable to combine type "array" with "${typeof answer}"`
-                                );
-                            }
-                        } else {
-                            throw new VError(
-                                `Question id "${questionId}" found more than once with unsupported type "${typeof existingAnswer}". Only arrays can be used to combine answers for a single id`
-                            );
-                        }
-                    } else {
-                        dataset.set(questionId, answer);
-                    }
-                });
-            }
-        });
-
-        return [
-            {
-                type: 'dataset',
-                id: 0,
-                attributes: Object.fromEntries(dataset)
-            }
-        ];
-    }
-
     async function createAnswers(questionnaireId, sectionId, answers) {
         // Make a copy of the supplied answers. These will be returned if they fail validation
         const rawAnswers = JSON.parse(JSON.stringify(answers));
@@ -602,7 +554,6 @@ function createQuestionnaireService({
         validateAllAnswers,
         getAnswers,
         getProgressEntries,
-        getDataset,
         sendConfirmationNotification,
         updateQuestionnaireSubmissionStatus
     });

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -5,6 +5,7 @@ const validateJWT = require('express-jwt');
 
 const createQuestionnaireService = require('./questionnaire-service');
 const permissions = require('../middleware/route-permissions');
+const datasetRouter = require('./dataset/dataset-routes.js');
 
 const router = express.Router();
 const rxTemplateName = /^[a-zA-Z0-9-]{1,30}$/;
@@ -38,21 +39,7 @@ router.route('/').post(permissions('create:questionnaires'), async (req, res, ne
     }
 });
 
-router
-    .route('/:questionnaireId/dataset')
-    .get(permissions('read:questionnaires', 'read:answers'), async (req, res, next) => {
-        try {
-            const {questionnaireId} = req.params;
-            const questionnaireService = createQuestionnaireService({logger: req.log});
-            const resourceCollection = await questionnaireService.getDataset(questionnaireId);
-
-            res.status(200).json({
-                data: resourceCollection
-            });
-        } catch (err) {
-            next(err);
-        }
-    });
+router.use(datasetRouter);
 
 router
     .route('/:questionnaireId/sections/answers')


### PR DESCRIPTION
As per [this issue](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/issues/134) and this [best practice](https://github.com/goldbergyoni/nodebestpractices/blob/master/sections/projectstructre/breakintcomponents.md). Extract out the dataset code to it's own component. This is in preparation for the revised dataset endpoint. 

All tests and coverage thresholds passing.