### PR TITLE
Notify integration test

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -32,7 +32,7 @@ config.coverageThreshold = {
         lines: 9,
         statements: 9
     },
-    './*/!(message-bus|notify|request)/**/*.js': {
+    './*/!(message-bus|request)/**/*.js': {
         statements: 54,
         branches: 60,
         functions: 50,
@@ -43,12 +43,6 @@ config.coverageThreshold = {
         branches: 60,
         functions: 0,
         lines: 15
-    },
-    './*/notify/**/*.js': {
-        statements: 42,
-        branches: 60,
-        functions: 0,
-        lines: 42
     },
     './*/request/**/*.js': {
         statements: 23,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2177,6 +2177,7 @@
             "version": "0.2.4",
             "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
             "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+            "dev": true,
             "requires": {
                 "safer-buffer": "~2.1.0"
             }
@@ -2212,7 +2213,8 @@
         "asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+            "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+            "dev": true
         },
         "atob": {
             "version": "2.1.2",
@@ -2228,12 +2230,14 @@
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+            "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+            "dev": true
         },
         "aws4": {
             "version": "1.9.1",
             "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+            "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+            "dev": true
         },
         "axios": {
             "version": "0.21.4",
@@ -2469,6 +2473,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
             "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+            "dev": true,
             "requires": {
                 "tweetnacl": "^0.14.3"
             }
@@ -2517,11 +2522,6 @@
             "requires": {
                 "file-uri-to-path": "1.0.0"
             }
-        },
-        "bluebird": {
-            "version": "3.7.2",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-            "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
         },
         "body-parser": {
             "version": "1.18.3",
@@ -2814,7 +2814,8 @@
         "caseless": {
             "version": "0.12.0",
             "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+            "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+            "dev": true
         },
         "chalk": {
             "version": "2.4.2",
@@ -3054,7 +3055,8 @@
         "co": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
-            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
+            "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=",
+            "dev": true
         },
         "code-error-fragment": {
             "version": "0.0.230",
@@ -3109,6 +3111,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "requires": {
                 "delayed-stream": "~1.0.0"
             }
@@ -3374,6 +3377,7 @@
             "version": "1.14.1",
             "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
             "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -3555,7 +3559,8 @@
         "delayed-stream": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+            "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+            "dev": true
         },
         "delegate": {
             "version": "3.2.0",
@@ -3684,6 +3689,7 @@
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
             "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+            "dev": true,
             "requires": {
                 "jsbn": "~0.1.0",
                 "safer-buffer": "^2.1.0"
@@ -4395,7 +4401,8 @@
         "extend": {
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+            "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+            "dev": true
         },
         "extend-shallow": {
             "version": "3.0.2",
@@ -4761,12 +4768,14 @@
         "forever-agent": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+            "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+            "dev": true
         },
         "form-data": {
             "version": "2.3.3",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
             "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+            "dev": true,
             "requires": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.6",
@@ -5437,6 +5446,7 @@
             "version": "0.1.7",
             "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
             "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0"
             }
@@ -5571,39 +5581,8 @@
         "har-schema": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-        },
-        "har-validator": {
-            "version": "5.0.3",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
-            "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
-            "requires": {
-                "ajv": "^5.1.0",
-                "har-schema": "^2.0.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "5.5.2",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
-                    "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-                    "requires": {
-                        "co": "^4.6.0",
-                        "fast-deep-equal": "^1.0.0",
-                        "fast-json-stable-stringify": "^2.0.0",
-                        "json-schema-traverse": "^0.3.0"
-                    }
-                },
-                "fast-deep-equal": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
-                    "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
-                },
-                "json-schema-traverse": {
-                    "version": "0.3.1",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
-                    "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
-                }
-            }
+            "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+            "dev": true
         },
         "has": {
             "version": "1.0.3",
@@ -5795,6 +5774,7 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
             "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+            "dev": true,
             "requires": {
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
@@ -6486,7 +6466,8 @@
         "is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+            "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+            "dev": true
         },
         "is-windows": {
             "version": "1.0.2",
@@ -6524,7 +6505,8 @@
         "isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+            "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+            "dev": true
         },
         "istanbul-lib-coverage": {
             "version": "3.0.0",
@@ -9337,7 +9319,8 @@
         "jsbn": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+            "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+            "dev": true
         },
         "jsdom": {
             "version": "16.5.3",
@@ -9495,7 +9478,8 @@
         "json-schema": {
             "version": "0.2.3",
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+            "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+            "dev": true
         },
         "json-schema-ref-parser": {
             "version": "6.1.0",
@@ -9542,7 +9526,8 @@
         "json-stringify-safe": {
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+            "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+            "dev": true
         },
         "json-to-ast": {
             "version": "2.1.0",
@@ -9605,6 +9590,7 @@
             "version": "1.4.1",
             "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
             "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+            "dev": true,
             "requires": {
                 "assert-plus": "1.0.0",
                 "extsprintf": "1.3.0",
@@ -9615,7 +9601,8 @@
                 "extsprintf": {
                     "version": "1.3.0",
                     "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+                    "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+                    "dev": true
                 }
             }
         },
@@ -10966,38 +10953,13 @@
             "integrity": "sha512-9UZCFRHQdNrfTpGg8+1INIg93B6zE0aXMVFkw1WFwvO4SlZywU6aLg5Of0Ap/PgcbSw4LNxvMWXMeugwMCX0AA=="
         },
         "notifications-node-client": {
-            "version": "4.7.3",
-            "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-4.7.3.tgz",
-            "integrity": "sha512-QWqFmCznBTGkQvKXGUuCmdjznwMRLyASrQieVfzCa3E4RmYLAvy97Bo/2EQlkgXgCJL2I7AO9KEkI7HE8xGNkQ==",
+            "version": "5.1.0",
+            "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.1.0.tgz",
+            "integrity": "sha512-a3aoSZPHSc/8VaccfGvKKsIZ/crqbglP9dNvg0pHHTgWi6BYiJc+Md7wOPizzEPACa+SKdifs06VY8ktbTzySA==",
             "requires": {
-                "jsonwebtoken": "8.2.1",
-                "request": "2.87.0",
-                "request-promise": "4.2.2",
+                "axios": "^0.21.1",
+                "jsonwebtoken": "^8.2.1",
                 "underscore": "^1.9.0"
-            },
-            "dependencies": {
-                "jsonwebtoken": {
-                    "version": "8.2.1",
-                    "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.2.1.tgz",
-                    "integrity": "sha512-l8rUBr0fqYYwPc8/ZGrue7GiW7vWdZtZqelxo4Sd5lMvuEeCK8/wS54sEo6tJhdZ6hqfutsj6COgC0d1XdbHGw==",
-                    "requires": {
-                        "jws": "^3.1.4",
-                        "lodash.includes": "^4.3.0",
-                        "lodash.isboolean": "^3.0.3",
-                        "lodash.isinteger": "^4.0.4",
-                        "lodash.isnumber": "^3.0.3",
-                        "lodash.isplainobject": "^4.0.6",
-                        "lodash.isstring": "^4.0.1",
-                        "lodash.once": "^4.0.0",
-                        "ms": "^2.1.1",
-                        "xtend": "^4.0.1"
-                    }
-                },
-                "ms": {
-                    "version": "2.1.2",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-                    "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-                }
             }
         },
         "npm-run-path": {
@@ -11238,11 +11200,6 @@
                     "dev": true
                 }
             }
-        },
-        "oauth-sign": {
-            "version": "0.8.2",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
-            "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "object-assign": {
             "version": "4.1.1",
@@ -11640,7 +11597,8 @@
         "performance-now": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+            "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+            "dev": true
         },
         "pg": {
             "version": "7.18.2",
@@ -12299,52 +12257,6 @@
             "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
             "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc=",
             "dev": true
-        },
-        "request": {
-            "version": "2.87.0",
-            "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
-            "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
-            "requires": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.6.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.5",
-                "extend": "~3.0.1",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.1",
-                "har-validator": "~5.0.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.17",
-                "oauth-sign": "~0.8.2",
-                "performance-now": "^2.1.0",
-                "qs": "~6.5.1",
-                "safe-buffer": "^5.1.1",
-                "tough-cookie": "~2.3.3",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.1.0"
-            }
-        },
-        "request-promise": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/request-promise/-/request-promise-4.2.2.tgz",
-            "integrity": "sha1-0epG1lSm7k+O5qT+oQGMIpEZBLQ=",
-            "requires": {
-                "bluebird": "^3.5.0",
-                "request-promise-core": "1.1.1",
-                "stealthy-require": "^1.1.0",
-                "tough-cookie": ">=2.3.3"
-            }
-        },
-        "request-promise-core": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/request-promise-core/-/request-promise-core-1.1.1.tgz",
-            "integrity": "sha1-Pu4AssWqgyOc+wTFcA2jb4HNCLY=",
-            "requires": {
-                "lodash": "^4.13.1"
-            }
         },
         "request-promise-native": {
             "version": "1.0.9",
@@ -13039,6 +12951,7 @@
             "version": "1.16.1",
             "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
             "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+            "dev": true,
             "requires": {
                 "asn1": "~0.2.3",
                 "assert-plus": "^1.0.0",
@@ -13097,7 +13010,8 @@
         "stealthy-require": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/stealthy-require/-/stealthy-require-1.1.1.tgz",
-            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks="
+            "integrity": "sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=",
+            "dev": true
         },
         "stickyfill": {
             "version": "1.1.1",
@@ -13827,6 +13741,7 @@
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
             "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+            "dev": true,
             "requires": {
                 "punycode": "^1.4.1"
             },
@@ -13834,7 +13749,8 @@
                 "punycode": {
                     "version": "1.4.1",
                     "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
+                    "dev": true
                 }
             }
         },
@@ -13871,6 +13787,7 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+            "dev": true,
             "requires": {
                 "safe-buffer": "^5.0.1"
             }
@@ -13878,7 +13795,8 @@
         "tweetnacl": {
             "version": "0.14.5",
             "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+            "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+            "dev": true
         },
         "type-check": {
             "version": "0.3.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
         "lodash.merge": "^4.6.2",
         "moment-timezone": "^0.5.33",
         "morgan": "^1.9.1",
-        "notifications-node-client": "^4.7.0",
+        "notifications-node-client": "^5.1.0",
         "pg": "^7.11.0",
         "pino-http": "^5.5.0",
         "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.5.3",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "3.0.4",
+    "version": "3.0.5",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",

--- a/services/notify/index.external.integration.test.js
+++ b/services/notify/index.external.integration.test.js
@@ -1,0 +1,145 @@
+'use strict';
+
+const createNotifyService = require('./index');
+
+describe('Notify service', () => {
+    const DUMMY_MOBILE_NUMBER_IN_USE = '07700900999';
+    const INVALID_MOBILE_NUMBER = 'abc';
+    const DUMMY_CASE_REFERENCE = '21\\456789';
+    const SIMULATE_REQUEST_ERROR = '07700901000';
+    const mockNotifyClient = {
+        sendSms: async (templateId, phoneNumber) => {
+            if (phoneNumber === DUMMY_MOBILE_NUMBER_IN_USE) {
+                const apiSuccessResponse = {
+                    data: {
+                        id: 'bfb50d92-100d-4b8b-b559-14fa3b091cda'
+                    }
+                };
+
+                return apiSuccessResponse;
+            }
+
+            if (phoneNumber === INVALID_MOBILE_NUMBER) {
+                const apiErrorResponse = {
+                    response: {
+                        data: {
+                            errors: [
+                                {
+                                    error: 'ValidationError',
+                                    message: 'phone_number Must not contain letters or symbols'
+                                }
+                            ],
+                            status_code: 400
+                        }
+                    }
+                };
+
+                throw apiErrorResponse;
+            }
+
+            if (phoneNumber === SIMULATE_REQUEST_ERROR) {
+                const requestError = {
+                    code: 'ERR_TLS_CERT_ALTNAME_INVALID',
+                    message:
+                        "Hostname/IP does not match certificate's altnames: Host: api.notifications.service.gov.uk. is not in the cert's altnames: DNS:*.cica.gov.uk, DNS:cica.gov.uk"
+                };
+
+                throw requestError;
+            }
+
+            throw Error('Issue with "Notify Client" mock.');
+        }
+    };
+
+    describe('Given a successful sms send request', () => {
+        it('should return the sms send request id', async () => {
+            const mockLogger = {error: () => {}};
+            const rxUUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-5][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+            const notifyService = createNotifyService({
+                logger: mockLogger,
+                notifyClient: mockNotifyClient
+            });
+            const smsSendRequest = await notifyService.sendSms({
+                templateId: '3c847bb8-957a-4bba-9fad-090657bb5c71',
+                phoneNumber: DUMMY_MOBILE_NUMBER_IN_USE,
+                personalisation: {
+                    caseReference: DUMMY_CASE_REFERENCE
+                }
+            });
+
+            expect(smsSendRequest.id).toMatch(rxUUID);
+        });
+    });
+
+    describe('Given an issue with an sms send request', () => {
+        it('should log an api error', async () => {
+            const mockLogger = {error: jest.fn()};
+            const notifyService = createNotifyService({
+                logger: mockLogger,
+                notifyClient: mockNotifyClient
+            });
+
+            await notifyService.sendSms({
+                templateId: '3c847bb8-957a-4bba-9fad-090657bb5c71',
+                phoneNumber: INVALID_MOBILE_NUMBER,
+                personalisation: {
+                    caseReference: DUMMY_CASE_REFERENCE
+                }
+            });
+
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        error: expect.any(String),
+                        message: expect.any(String)
+                    })
+                ]),
+                'SMS SEND FAILURE'
+            );
+        });
+
+        it('should log a request error', async () => {
+            const mockLogger = {error: jest.fn()};
+            const notifyService = createNotifyService({
+                logger: mockLogger,
+                notifyClient: mockNotifyClient
+            });
+
+            await notifyService.sendSms({
+                templateId: '3c847bb8-957a-4bba-9fad-090657bb5c71',
+                phoneNumber: SIMULATE_REQUEST_ERROR,
+                personalisation: {
+                    caseReference: DUMMY_CASE_REFERENCE
+                }
+            });
+
+            expect(mockLogger.error).toHaveBeenCalledWith(
+                expect.arrayContaining([
+                    expect.objectContaining({
+                        error: expect.any(String),
+                        message: expect.any(String)
+                    })
+                ]),
+                'SMS SEND FAILURE'
+            );
+        });
+
+        it('should return an undefined smsSendRequest', async () => {
+            const mockLogger = {error: jest.fn()};
+            const notifyService = createNotifyService({
+                logger: mockLogger,
+                notifyClient: mockNotifyClient
+            });
+
+            const smsSendRequest = await notifyService.sendSms({
+                templateId: '3c847bb8-957a-4bba-9fad-090657bb5c71',
+                phoneNumber: INVALID_MOBILE_NUMBER,
+                personalisation: {
+                    caseReference: DUMMY_CASE_REFERENCE
+                }
+            });
+
+            expect(smsSendRequest).toEqual(undefined);
+        });
+    });
+});

--- a/services/notify/index.js
+++ b/services/notify/index.js
@@ -5,24 +5,55 @@ const createMessageBusCaller = require('../message-bus');
 
 const {NotifyClient} = notificationNodeClient;
 const apiKey = process.env.NOTIFY_API_KEY;
-const notifyClient = new NotifyClient(apiKey);
+const sharedNotifyClient = new NotifyClient(apiKey);
 
 function createNotifyService(spec) {
-    const {logger} = spec;
-    async function sendSms(options) {
-        let response;
-        try {
-            response = notifyClient.sendSms(options.templateId, options.phoneNumber, {
-                personalisation: {
-                    case_reference: options.personalisation.caseReference
-                },
-                reference: null
-            });
-        } catch (err) {
-            logger.error({err}, 'SMS SEND FAILURE');
+    const {logger, notifyClient = sharedNotifyClient} = spec;
+
+    // https://github.com/axios/axios/issues/4080
+    function normaliseSmsSendRequestError(error) {
+        const isApiResponseError = error.response !== undefined;
+
+        if (isApiResponseError) {
+            return error.response.data.errors;
         }
 
-        return response;
+        const requestError = [
+            {
+                error: error.code,
+                message: error.message
+            }
+        ];
+
+        return requestError;
+    }
+
+    async function sendSms(options) {
+        try {
+            const smsSendRequest = await notifyClient.sendSms(
+                options.templateId,
+                options.phoneNumber,
+                {
+                    personalisation: {
+                        case_reference: options.personalisation.caseReference
+                    },
+                    reference: null
+                }
+            );
+
+            // This DOES NOT indicate that the sms was successfully delivered,
+            // only that the request to send the sms was successful. In future, the id
+            // could be used to further query the status of the request.
+            return {
+                id: smsSendRequest.data.id
+            };
+        } catch (err) {
+            const normalisedError = normaliseSmsSendRequestError(err);
+
+            logger.error(normalisedError, 'SMS SEND FAILURE');
+        }
+
+        return undefined;
     }
 
     async function sendEmail(options) {


### PR DESCRIPTION
Adds an integration test for the current notify service. This is in preparation for a major version bump to `notifications-node-client`.

Adds a `test:local` npm script which allows the integration test to be excluded.

Update: Now has the notifications-node-client 5.1.0

