### PR TITLE
Add get attributes from section functionailty

### DIFF
--- a/questionnaire/section/section.js
+++ b/questionnaire/section/section.js
@@ -1,0 +1,129 @@
+'use strict';
+
+function createSection({sectionDefinition}) {
+    function getAttributeFormat(attributeSchema) {
+        if ('format' in attributeSchema) {
+            const format = {
+                value: attributeSchema.format
+            };
+
+            if (
+                'meta' in attributeSchema &&
+                'keywords' in attributeSchema.meta &&
+                'format' in attributeSchema.meta.keywords
+            ) {
+                const formatMetadata = attributeSchema.meta.keywords.format;
+
+                return {...format, ...formatMetadata};
+            }
+
+            return format;
+        }
+
+        return undefined;
+    }
+
+    function getCompositeAttributeId(attributeSchema) {
+        return attributeSchema.meta.compositeId;
+    }
+
+    function getAttributeLabel(valueSchemas, value) {
+        const foundValueSchema = valueSchemas.find(valueSchema => valueSchema.const === value);
+
+        return foundValueSchema.title;
+    }
+
+    function getAttributeLabels(valueSchemas, values) {
+        return values.map(value => getAttributeLabel(valueSchemas, value));
+    }
+
+    function getValueLabel(attributeSchema, value) {
+        const {oneOf, items} = attributeSchema;
+
+        if (oneOf !== undefined) {
+            return getAttributeLabel(oneOf, value);
+        }
+
+        if (items !== undefined) {
+            return getAttributeLabels(items.anyOf, value);
+        }
+
+        return undefined;
+    }
+
+    function createSimpleAttribute(id, attributeSchema, data) {
+        const format = getAttributeFormat(attributeSchema);
+        const value = data[id];
+        const valueLabel = getValueLabel(attributeSchema, value);
+        const simpleAttribute = {
+            id,
+            type: 'simple',
+            label: attributeSchema.title
+        };
+
+        if (format !== undefined) {
+            simpleAttribute.format = format;
+        }
+
+        if (value !== undefined) {
+            simpleAttribute.value = value;
+        }
+
+        if (valueLabel !== undefined) {
+            simpleAttribute.valueLabel = valueLabel;
+        }
+
+        return simpleAttribute;
+    }
+
+    function createCompositeAttribute(compositeAttributeSchema) {
+        const compositeAttribute = {
+            id: getCompositeAttributeId(compositeAttributeSchema),
+            type: 'composite',
+            label: compositeAttributeSchema.title,
+            values: []
+        };
+
+        return compositeAttribute;
+    }
+
+    function getAttributesByData(data = {}, schema = sectionDefinition.schema) {
+        const {properties, allOf} = schema;
+        const attributes = [];
+
+        if (properties !== undefined) {
+            Object.keys(data).forEach(attributeId => {
+                const questionSchema = properties[attributeId];
+
+                if (questionSchema !== undefined) {
+                    const attribute = createSimpleAttribute(attributeId, questionSchema, data);
+
+                    attributes.push(attribute);
+                }
+            });
+
+            return attributes;
+        }
+
+        if (allOf !== undefined) {
+            const compositeAttributeSchema = allOf[0];
+            const compositeAttribute = createCompositeAttribute(compositeAttributeSchema);
+
+            compositeAttributeSchema.allOf.forEach(subSchema => {
+                compositeAttribute.values.push(...getAttributesByData(data, subSchema));
+            });
+
+            attributes.push(compositeAttribute);
+
+            return attributes;
+        }
+
+        return [];
+    }
+
+    return Object.freeze({
+        getAttributesByData
+    });
+}
+
+module.exports = createSection;

--- a/questionnaire/section/section.test.js
+++ b/questionnaire/section/section.test.js
@@ -1,0 +1,220 @@
+'use strict';
+
+const fixtures = require('./test-fixtures');
+const createSection = require('./section');
+
+describe('Section', () => {
+    describe('getAttributesByData', () => {
+        describe('Given a section definition containing a schema', () => {
+            describe('And the schema contains an attribute that can accept a single value', () => {
+                it('should return a simple attribute with a label and single value', async () => {
+                    const section = createSection({
+                        sectionDefinition: fixtures.sectionWithSimpleAttributeSingleValue
+                    });
+                    const data = {
+                        'q-applicant-enter-your-email-address':
+                            'bar@9f7b855e-586b-49f0-ac7a-026919732b06.gov.uk'
+                    };
+                    const sectionAttributes = section.getAttributesByData(data);
+
+                    expect(sectionAttributes).toEqual([
+                        {
+                            id: 'q-applicant-enter-your-email-address',
+                            type: 'simple',
+                            label: 'Enter your email address',
+                            value: 'bar@9f7b855e-586b-49f0-ac7a-026919732b06.gov.uk',
+                            format: {
+                                value: 'email'
+                            }
+                        }
+                    ]);
+                });
+
+                it('should include any value format metadata', () => {
+                    const section = createSection({
+                        sectionDefinition: {
+                            schema: {
+                                type: 'object',
+                                properties: {
+                                    'q-applicant-when-did-the-crime-start': {
+                                        title: 'When did it start?',
+                                        meta: {
+                                            keywords: {
+                                                format: {
+                                                    precision: 'YYYY-MM',
+                                                    defaults: {
+                                                        DD: '01'
+                                                    }
+                                                }
+                                            }
+                                        },
+                                        type: 'string',
+                                        format: 'date-time',
+                                        description:
+                                            'For example, 02 2020. You can enter an approximate date.'
+                                    }
+                                }
+                            }
+                        }
+                    });
+                    const data = {
+                        'q-applicant-when-did-the-crime-start': '2021-01-01T00:00:00.000Z'
+                    };
+                    const sectionAttributes = section.getAttributesByData(data);
+
+                    expect(sectionAttributes).toEqual([
+                        {
+                            id: 'q-applicant-when-did-the-crime-start',
+                            type: 'simple',
+                            label: 'When did it start?',
+                            value: '2021-01-01T00:00:00.000Z',
+                            format: {
+                                value: 'date-time',
+                                precision: 'YYYY-MM',
+                                defaults: {
+                                    DD: '01'
+                                }
+                            }
+                        }
+                    ]);
+                });
+
+                describe('Given the supplied data has no corresponding keys in the section schema', () => {
+                    it('should return an empty list of attributes', async () => {
+                        const section = createSection({
+                            sectionDefinition: fixtures.sectionWithSimpleAttributeSingleValue
+                        });
+                        const data = {
+                            'this-key-does-not-exist-in-the-section-schema': 'dummy value'
+                        };
+                        const sectionAttributes = section.getAttributesByData(data);
+
+                        expect(sectionAttributes).toEqual([]);
+                    });
+                });
+            });
+
+            describe('And the schema contains an attribute that can accept a single predefined value', () => {
+                it('should return a simple attribute with a label and single value label', async () => {
+                    const section = createSection({
+                        sectionDefinition: fixtures.sectionWithSimpleAttributeSinglePredefinedValue
+                    });
+                    const data = {
+                        'q-applicant-british-citizen-or-eu-national': true
+                    };
+                    const sectionAttributes = section.getAttributesByData(data);
+
+                    expect(sectionAttributes).toEqual([
+                        {
+                            id: 'q-applicant-british-citizen-or-eu-national',
+                            type: 'simple',
+                            label: 'Are you a British citizen or EU national?',
+                            value: true,
+                            valueLabel: 'Yes'
+                        }
+                    ]);
+                });
+            });
+
+            describe('And the schema contains an attribute that can accept multiple predefined values', () => {
+                it('should return a simple attribute with a label and multiple value labels', async () => {
+                    const section = createSection({
+                        sectionDefinition:
+                            fixtures.sectionWithSimpleAttributeMultiplePredefinedValues
+                    });
+                    const data = {
+                        'q-applicant-physical-injury-upper': ['head', 'eye', 'nose']
+                    };
+                    const sectionAttributes = section.getAttributesByData(data);
+
+                    expect(sectionAttributes).toEqual([
+                        {
+                            id: 'q-applicant-physical-injury-upper',
+                            type: 'simple',
+                            label: 'What parts of the head, face or neck was injured?',
+                            value: ['head', 'eye', 'nose'],
+                            valueLabel: ['Head or brain', 'Eye or eyesight', 'Nose']
+                        }
+                    ]);
+                });
+            });
+
+            describe('And the schema contains a single composite attribute', () => {
+                it('should return a composite attribute', async () => {
+                    const section = createSection({
+                        sectionDefinition: fixtures.sectionWithSingleCompositeAttribute
+                    });
+                    const data = {
+                        'q-applicant-title': 'Mr',
+                        'q-applicant-first-name': 'Foo',
+                        'q-applicant-last-name': 'Bar'
+                    };
+                    const sectionAttributes = section.getAttributesByData(data);
+
+                    expect(sectionAttributes).toEqual([
+                        {
+                            id: 'q-fullname',
+                            type: 'composite',
+                            label: 'Enter your name',
+                            values: [
+                                {
+                                    id: 'q-applicant-title',
+                                    type: 'simple',
+                                    label: 'Title',
+                                    value: 'Mr'
+                                },
+                                {
+                                    id: 'q-applicant-first-name',
+                                    type: 'simple',
+                                    label: 'First name',
+                                    value: 'Foo'
+                                },
+                                {
+                                    id: 'q-applicant-last-name',
+                                    type: 'simple',
+                                    label: 'Last name',
+                                    value: 'Bar'
+                                }
+                            ]
+                        }
+                    ]);
+                });
+
+                describe('Given the supplied data has two of the three corresponding composite attribute keys', () => {
+                    it('should return a composite attribute with two corresponding attributes', async () => {
+                        const section = createSection({
+                            sectionDefinition: fixtures.sectionWithSingleCompositeAttribute
+                        });
+                        const data = {
+                            'q-applicant-title': 'Mr',
+                            'q-applicant-last-name': 'Bar'
+                        };
+                        const sectionAttributes = section.getAttributesByData(data);
+
+                        expect(sectionAttributes).toEqual([
+                            {
+                                id: 'q-fullname',
+                                type: 'composite',
+                                label: 'Enter your name',
+                                values: [
+                                    {
+                                        id: 'q-applicant-title',
+                                        type: 'simple',
+                                        label: 'Title',
+                                        value: 'Mr'
+                                    },
+                                    {
+                                        id: 'q-applicant-last-name',
+                                        type: 'simple',
+                                        label: 'Last name',
+                                        value: 'Bar'
+                                    }
+                                ]
+                            }
+                        ]);
+                    });
+                });
+            });
+        });
+    });
+});

--- a/questionnaire/section/test-fixtures/index.js
+++ b/questionnaire/section/test-fixtures/index.js
@@ -1,0 +1,165 @@
+'use strict';
+
+const attributes = {
+    simple: {
+        singleValue: {
+            'q-applicant-enter-your-email-address': {
+                type: 'string',
+                title: 'Enter your email address',
+                description:
+                    'We may use this to contact you if we need to clarify something on your application form (optional).',
+                maxLength: 50,
+                format: 'email'
+            }
+        },
+        singlePredefinedValue: {
+            'q-applicant-british-citizen-or-eu-national': {
+                title: 'Are you a British citizen or EU national?',
+                type: 'boolean',
+                oneOf: [
+                    {
+                        title: 'Yes',
+                        const: true
+                    },
+                    {
+                        title: 'No',
+                        const: false
+                    }
+                ]
+            }
+        },
+        multiplePredefinedValues: {
+            'q-applicant-physical-injury-upper': {
+                title: 'What parts of the head, face or neck was injured?',
+                type: 'array',
+                items: {
+                    anyOf: [
+                        {
+                            title: 'Head or brain',
+                            const: 'head'
+                        },
+                        {
+                            title: 'Face or jaw',
+                            const: 'face'
+                        },
+                        {
+                            title: 'Eye or eyesight',
+                            const: 'eye'
+                        },
+                        {
+                            title: 'Ear or hearing',
+                            const: 'ear'
+                        },
+                        {
+                            title: 'Nose',
+                            const: 'nose'
+                        },
+                        {
+                            title: 'Mouth',
+                            const: 'mouth'
+                        },
+                        {
+                            title: 'Neck',
+                            const: 'neck'
+                        },
+                        {
+                            title: 'Skin',
+                            const: 'skin',
+                            description: 'Including cuts, bruises, burns and scars'
+                        },
+                        {
+                            title: 'Tissue',
+                            const: 'muscle',
+                            description: 'Including muscles, ligaments, tendons or cartilage'
+                        }
+                    ]
+                }
+            }
+        }
+    },
+    composite: {
+        title: 'Enter your name',
+        required: ['q-applicant-title', 'q-applicant-first-name', 'q-applicant-last-name'],
+        propertyNames: {
+            enum: ['q-applicant-title', 'q-applicant-first-name', 'q-applicant-last-name']
+        },
+        meta: {
+            compositeId: 'q-fullname'
+        },
+        allOf: [
+            {
+                properties: {
+                    'q-applicant-title': {
+                        title: 'Title',
+                        type: 'string',
+                        maxLength: 6,
+                        errorMessage: {
+                            maxLength: 'Title must be 6 characters or less'
+                        }
+                    }
+                }
+            },
+            {
+                properties: {
+                    'q-applicant-first-name': {
+                        title: 'First name',
+                        type: 'string',
+                        maxLength: 70,
+                        errorMessage: {
+                            maxLength: 'First name must be 70 characters or less'
+                        }
+                    }
+                }
+            },
+            {
+                properties: {
+                    'q-applicant-last-name': {
+                        title: 'Last name',
+                        type: 'string',
+                        maxLength: 70,
+                        errorMessage: {
+                            maxLength: 'Last name must be 70 characters or less'
+                        }
+                    }
+                }
+            }
+        ]
+    }
+};
+
+module.exports = {
+    sectionWithSimpleAttributeSingleValue: {
+        schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+                ...attributes.simple.singleValue
+            }
+        }
+    },
+    sectionWithSimpleAttributeSinglePredefinedValue: {
+        schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+                ...attributes.simple.singlePredefinedValue
+            }
+        }
+    },
+    sectionWithSimpleAttributeMultiplePredefinedValues: {
+        schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            properties: {
+                ...attributes.simple.multiplePredefinedValues
+            }
+        }
+    },
+    sectionWithSingleCompositeAttribute: {
+        schema: {
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'object',
+            allOf: [attributes.composite]
+        }
+    }
+};


### PR DESCRIPTION
Both the dataset endpoint and the answer summary page require getting attributes from sections. This PR provides that functionality.

All tests passing.