### PR TITLE
Bump express-jwt 7.4.3

### DIFF
--- a/middleware/route-permissions/index.js
+++ b/middleware/route-permissions/index.js
@@ -6,7 +6,7 @@ const jwtAuthz = require('express-jwt-authz');
 // wrap it to avoid passing it in manually on every call
 function permissions(...scopes) {
     // This returns a middleware function
-    return jwtAuthz(scopes, {failWithError: true});
+    return jwtAuthz(scopes, {failWithError: true, customUserKey: 'auth'});
 }
 
 module.exports = permissions;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2202,7 +2202,8 @@
         "async": {
             "version": "1.5.2",
             "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
+            "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
+            "dev": true
         },
         "async-each": {
             "version": "1.0.3",
@@ -4356,14 +4357,12 @@
             }
         },
         "express-jwt": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-6.1.0.tgz",
-            "integrity": "sha512-mmSR52Ps1FMeGwchroHzEJONWhsobd5KHVVKBffYiUEpZh9iK9wI9ZWkmzY5ROwWQtJLNGHV/VUMLh2M208s4Q==",
+            "version": "7.4.3",
+            "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-7.4.3.tgz",
+            "integrity": "sha512-sdRg9UiPW7QVywSlFl2cJALZWndxBM4HGyNqH7FyzDMYtboyBhssfLAD3ZYklraQz+wGR4Q3YsMipXZrNsQT5A==",
             "requires": {
-                "async": "^1.5.0",
                 "express-unless": "^1.0.0",
-                "jsonwebtoken": "^8.1.0",
-                "lodash.set": "^4.0.0"
+                "jsonwebtoken": "^8.5.1"
             }
         },
         "express-jwt-authz": {
@@ -10198,11 +10197,6 @@
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
             "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
-        },
-        "lodash.set": {
-            "version": "4.3.2",
-            "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-            "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
         },
         "log-symbols": {
             "version": "3.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4366,9 +4366,9 @@
             }
         },
         "express-jwt-authz": {
-            "version": "2.3.1",
-            "resolved": "https://registry.npmjs.org/express-jwt-authz/-/express-jwt-authz-2.3.1.tgz",
-            "integrity": "sha512-cChqAjXe8E3KDe4XbmkpYpk/vQdy4s3n1ccxVgij+2F0rS86hiOQvTrYnHBc1jZstqpGrOzLgHMByh046fKgyQ=="
+            "version": "2.4.1",
+            "resolved": "https://registry.npmjs.org/express-jwt-authz/-/express-jwt-authz-2.4.1.tgz",
+            "integrity": "sha512-ruH86e2NvWicG9maStztyAyBJV0E8RsInXUm6Kuc/9pDtVJmJw3qigv1MEVs5bH+aksZuxocYZdz+N1V/9F+Dg=="
         },
         "express-openapi-validator": {
             "version": "1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "5.0.0",
+    "version": "6.0.0",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
         "cookie-parser": "~1.4.3",
         "debug": "~2.6.9",
         "express": "~4.16.0",
-        "express-jwt": "^6.1.0",
+        "express-jwt": "^7.4.3",
         "express-jwt-authz": "^2.3.1",
         "express-openapi-validator": "^1.6.2",
         "got": "^9.6.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "debug": "~2.6.9",
         "express": "~4.16.0",
         "express-jwt": "^7.4.3",
-        "express-jwt-authz": "^2.3.1",
+        "express-jwt-authz": "^2.4.1",
         "express-openapi-validator": "^1.6.2",
         "got": "^9.6.0",
         "helmet": "^3.21.2",

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const express = require('express');
-const validateJWT = require('express-jwt');
+const {expressjwt: validateJWT} = require('express-jwt');
 
 const createQuestionnaireService = require('./questionnaire-service');
 const permissions = require('../middleware/route-permissions');
@@ -9,7 +9,6 @@ const datasetRouter = require('./dataset/dataset-routes.js');
 
 const router = express.Router();
 const rxTemplateName = /^[a-zA-Z0-9-]{1,30}$/;
-
 // Ensure JWT is valid
 router.use(validateJWT({secret: process.env.DCS_JWT_SECRET, algorithms: ['HS256']}));
 

--- a/questionnaire/submissions-routes.js
+++ b/questionnaire/submissions-routes.js
@@ -1,7 +1,7 @@
 'use strict';
 
 const express = require('express');
-const validateJWT = require('express-jwt');
+const {expressjwt: validateJWT} = require('express-jwt');
 
 const createSubmissionsService = require('./submissions-service');
 const permissions = require('../middleware/route-permissions');


### PR DESCRIPTION
Bump `express-jwt` from `6.1.0` to `7.4.3`
Bump `express-jwt-authz` from `2.3.1` to `2.4.1`

Unit tests, and manual tests tested successfully.

Breaking change, explained [here](https://github.com/auth0/express-jwt/issues/283)

Proposed version bump: `v6.0.0`