### PR TITLE
Feature/replace child with victim

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12006,8 +12006,8 @@
             }
         },
         "q-templates-application": {
-            "version": "github:CriminalInjuriesCompensationAuthority/q-templates-application#4e9abea4a84be149b3599bd4238112615cdd6cca",
-            "from": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v6.0.3"
+            "version": "github:CriminalInjuriesCompensationAuthority/q-templates-application#bfcaec7b79b44abc980cf858ef32f632d2461293",
+            "from": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v6.0.4"
         },
         "qs": {
             "version": "6.5.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "5.0.3",
+    "version": "5.0.4",
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L --inspect=0.0.0.0:9229 -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "pg": "^7.11.0",
         "pino-http": "^5.5.0",
         "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v2.6.0",
-        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v6.0.3",
+        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v6.0.4",
         "swagger-ui-express": "^4.3.0",
         "uuid": "^3.3.2",
         "verror": "^1.10.0"


### PR DESCRIPTION
Bump `q-templates-application` to `v6.0.4`. Includes:
* Swapping out `child` for `victim`
* Minor grammar fix
Proposed version bump: `v5.0.4` (patch)