### PR TITLE
Feature/cica 315/session

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -26,12 +26,6 @@ config.coverageThreshold = {
         functions: 0,
         lines: 35,
         statements: 35
-    },
-    './questionnaire/questionnaire-dal.js': {
-        branches: 20,
-        functions: 37,
-        lines: 24,
-        statements: 26
     }
 };
 

--- a/kube_deploy/Dev/deploy.yml
+++ b/kube_deploy/Dev/deploy.yml
@@ -47,6 +47,8 @@ spec:
               value: https://data-capture-service.dev.claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: APP_ENV
               value: dev
+            - name: DCS_SESSION_DURATION
+              value: '900000'
             - name: WEBHOOK_TEAM_REPORTER_SLACK
               valueFrom:
                 secretKeyRef:

--- a/kube_deploy/Prod/deploy.yml
+++ b/kube_deploy/Prod/deploy.yml
@@ -47,6 +47,8 @@ spec:
               value: https://data-capture-service.claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: APP_ENV
               value: prod
+            - name: DCS_SESSION_DURATION
+              value: '1800000'
             - name: WEBHOOK_TEAM_REPORTER_SLACK
               valueFrom:
                 secretKeyRef:

--- a/kube_deploy/Uat/deploy.yml
+++ b/kube_deploy/Uat/deploy.yml
@@ -47,6 +47,8 @@ spec:
               value: https://data-capture-service.uat.claim-criminal-injuries-compensation.service.justice.gov.uk
             - name: APP_ENV
               value: uat
+            - name: DCS_SESSION_DURATION
+              value: '1800000'
             - name: WEBHOOK_TEAM_REPORTER_SLACK
               valueFrom:
                 secretKeyRef:

--- a/openapi/openapi.json
+++ b/openapi/openapi.json
@@ -31,6 +31,9 @@
         },
         {
             "name": "ProgressEntries"
+        },
+        {
+            "name": "Sessions"
         }
     ],
     "paths": {
@@ -2991,6 +2994,326 @@
                                         {
                                             "status": 401,
                                             "detail": "No authorization token was found"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "404": {
+                        "description": "The specified resource was not found",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [404]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["404 Not Found"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 404,
+                                            "title": "404 Not Found",
+                                            "detail": "Resource /api/v1/questionnaires/2d7caf89-2c72-469f-b19d-17f2a22270b6/sections/answers does not exist"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/questionnaires/{questionnaireId}/session/keep-alive": {
+            "get": {
+                "tags": ["Sessions"],
+                "summary": "Refresh session.",
+                "description": "Refresh the session related to a specific questionnaire id.",
+                "operationId": "RefreshSession  ",
+                "parameters": [
+                    {
+                        "name": "questionnaireId",
+                        "in": "path",
+                        "required": true,
+                        "description": "The id of the specific questionnaire instance. Format UUIDv4.",
+                        "schema": {
+                            "title": "UUID v4",
+                            "type": "string",
+                            "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                        },
+                        "example": "285cb104-0c15-4a9c-9840-cb1007f098fb"
+                    }
+                ],
+                "x-scopes": ["update:questionnaires"],
+                "x-requests": {
+                    "400": {
+                        "parameters": [
+                            {
+                                "name": "questionnaireId",
+                                "example": "NOT-A-UUID"
+                            }
+                        ]
+                    },
+                    "401": {
+                        "auth": false
+                    },
+                    "403": {
+                        "x-scopes": ["create:dummy-resource"]
+                    },
+                    "404": {
+                        "parameters": [
+                            {
+                                "name": "questionnaireId",
+                                "example": "68653be7-877f-4106-b91e-4ba8dac883f4"
+                            }
+                        ]
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "title": "Sessions resource",
+                                    "allOf": [
+                                        {
+                                            "title": "Loosely describes the JSON:API document format",
+                                            "type": "object",
+                                            "additionalProperties": false,
+                                            "required": ["data"],
+                                            "properties": {
+                                                "data": {
+                                                    "anyOf": [
+                                                        {
+                                                            "type": "object"
+                                                        },
+                                                        {
+                                                            "type": "array",
+                                                            "items": {}
+                                                        }
+                                                    ]
+                                                },
+                                                "included": {
+                                                    "type": "array",
+                                                    "items": {}
+                                                },
+                                                "links": {
+                                                    "type": "object"
+                                                },
+                                                "meta": {
+                                                    "type": "object"
+                                                }
+                                            }
+                                        },
+                                        {
+                                            "properties": {
+                                                "data": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "title": "Session resource",
+                                                        "allOf": [
+                                                            {
+                                                                "properties": {
+                                                                    "data": {
+                                                                        "type": "array",
+                                                                        "items": {
+                                                                            "properties": {
+                                                                                "type": {
+                                                                                    "enum": [
+                                                                                        "sessions"
+                                                                                    ]
+                                                                                },
+                                                                                "id": {
+                                                                                    "type": "string",
+                                                                                    "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                                                                                },
+                                                                                "attributes": {
+                                                                                    "type": "object",
+                                                                                    "additionalProperties": false,
+                                                                                    "required": [
+                                                                                        "alive",
+                                                                                        "duration",
+                                                                                        "created",
+                                                                                        "expires"
+                                                                                    ],
+                                                                                    "properties": {
+                                                                                        "alive": {
+                                                                                            "type": "boolean"
+                                                                                        },
+                                                                                        "duration": {
+                                                                                            "type": "integer",
+                                                                                            "minimum": 1
+                                                                                        },
+                                                                                        "created": {
+                                                                                            "type": "integer"
+                                                                                        },
+                                                                                        "expires": {
+                                                                                            "type": "integer"
+                                                                                        }
+                                                                                    }
+                                                                                }
+                                                                            }
+                                                                        }
+                                                                    }
+                                                                }
+                                                            }
+                                                        ]
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    ]
+                                },
+                                "example": {
+                                    "data": [
+                                        {
+                                            "id": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                            "type": "sessions",
+                                            "attributes": {
+                                                "alive": true,
+                                                "duration": 900000,
+                                                "created": 1660249595000,
+                                                "expires": 1660250495000
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "There is an issue with the request",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [400]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["400 Bad Request"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 400,
+                                            "title": "400 Bad Request",
+                                            "detail": "Request JSON is malformed"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "401": {
+                        "description": "Access token is missing or invalid",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [401]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["401 Unauthorized"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 401,
+                                            "detail": "No authorization token was found"
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "403": {
+                        "description": "The JWT doesn't permit access to this endpoint",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "type": "object",
+                                    "required": ["errors"],
+                                    "properties": {
+                                        "errors": {
+                                            "type": "array",
+                                            "items": {
+                                                "type": "object",
+                                                "required": ["status", "title", "detail"],
+                                                "properties": {
+                                                    "status": {
+                                                        "enum": [403]
+                                                    },
+                                                    "title": {
+                                                        "enum": ["403 Forbidden"]
+                                                    },
+                                                    "detail": {
+                                                        "type": "string"
+                                                    }
+                                                }
+                                            }
+                                        }
+                                    }
+                                },
+                                "example": {
+                                    "errors": [
+                                        {
+                                            "status": 403,
+                                            "title": "403 Forbidden",
+                                            "detail": "Insufficient scope"
                                         }
                                     ]
                                 }

--- a/openapi/src/json-schemas/api/_questionnaires_{questionnaireId}_sessions/get/res/200.json
+++ b/openapi/src/json-schemas/api/_questionnaires_{questionnaireId}_sessions/get/res/200.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Sessions resource",
+    "allOf": [
+        {"$ref": "../../../json-api-base-document.json"},
+        {
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "../../../resources/session-resource.json"
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/openapi/src/json-schemas/api/resources/session-resource.json
+++ b/openapi/src/json-schemas/api/resources/session-resource.json
@@ -1,0 +1,44 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "title": "Session resource",
+    "allOf": [
+        {
+            "properties": {
+                "data": {
+                    "type": "array",
+                    "items": {
+                        "properties": {
+                            "type": {
+                                "const": "sessions"
+                            },
+                            "id": {
+                                "type": "string",
+                                "pattern": "^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$"
+                            },
+                            "attributes": {
+                                "type": "object",
+                                "additionalProperties": false,
+                                "required": ["alive", "duration", "created", "expires"],
+                                "properties": {
+                                    "alive": {
+                                        "type": "boolean"
+                                    },
+                                    "duration": {
+                                        "type": "integer",
+                                        "minimum": 1
+                                    },
+                                    "created": {
+                                        "type": "integer"
+                                    },
+                                    "expires": {
+                                        "type": "integer"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    ]
+}

--- a/openapi/src/openapi-src.json
+++ b/openapi/src/openapi-src.json
@@ -22,7 +22,12 @@
             "bearerAuth": []
         }
     ],
-    "tags": [{"name": "Answers"}, {"name": "Questionnaires"}, {"name": "ProgressEntries"}],
+    "tags": [
+        {"name": "Answers"},
+        {"name": "Questionnaires"},
+        {"name": "ProgressEntries"},
+        {"name": "Sessions"}
+    ],
     "paths": {
         "/questionnaires": {
             "post": {
@@ -802,6 +807,82 @@
                     },
                     "401": {
                         "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "404": {
+                        "$ref": "#/components/responses/NotFound"
+                    }
+                }
+            }
+        },
+        "/questionnaires/{questionnaireId}/session/keep-alive": {
+            "get": {
+                "tags": ["Sessions"],
+                "summary": "Refresh session.",
+                "description": "Refresh the session related to a specific questionnaire id.",
+                "operationId": "RefreshSession  ",
+                "parameters": [
+                    {
+                        "$ref": "#/components/parameters/questionnaireId"
+                    }
+                ],
+                "x-scopes": ["update:questionnaires"],
+                "x-requests": {
+                    "400": {
+                        "parameters": [
+                            {
+                                "name": "questionnaireId",
+                                "example": "NOT-A-UUID"
+                            }
+                        ]
+                    },
+                    "401": {
+                        "auth": false
+                    },
+                    "403": {
+                        "x-scopes": ["create:dummy-resource"]
+                    },
+                    "404": {
+                        "parameters": [
+                            {
+                                "name": "questionnaireId",
+                                "example": "68653be7-877f-4106-b91e-4ba8dac883f4"
+                            }
+                        ]
+                    }
+                },
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/vnd.api+json": {
+                                "schema": {
+                                    "$ref": "json-schemas/api/_questionnaires_{questionnaireId}_sessions/get/res/200.json"
+                                },
+                                "example": {
+                                    "data": [
+                                        {
+                                            "id": "285cb104-0c15-4a9c-9840-cb1007f098fb",
+                                            "type": "sessions",
+                                            "attributes": {
+                                                "alive": true,
+                                                "duration": 900000,
+                                                "created": 1660249595000,
+                                                "expires": 1660250495000
+                                            }
+                                        }
+                                    ]
+                                }
+                            }
+                        }
+                    },
+                    "400": {
+                        "$ref": "#/components/responses/BadRequest"
+                    },
+                    "401": {
+                        "$ref": "#/components/responses/UnauthorizedError"
+                    },
+                    "403": {
+                        "$ref": "#/components/responses/Forbidden"
                     },
                     "404": {
                         "$ref": "#/components/responses/NotFound"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "6.0.13",
+    "version": "6.1.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "6.0.13",
+            "version": "6.1.0",
             "license": "MIT",
             "dependencies": {
                 "@netflix/nerror": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "6.0.13",
+    "version": "6.1.0",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"

--- a/questionnaire/questionnaire-dal.js
+++ b/questionnaire/questionnaire-dal.js
@@ -132,13 +132,60 @@ function questionnaireDAL(spec) {
         return result.rowCount ? result.rows.map(x => x.id) : [];
     }
 
+    async function getQuestionnaireModifiedDate(questionnaireId) {
+        let result;
+        try {
+            result = await db.query('SELECT modified FROM questionnaire WHERE id = $1', [
+                questionnaireId
+            ]);
+
+            if (result.rowCount === 0) {
+                throw new VError(
+                    {
+                        name: 'ResourceNotFound'
+                    },
+                    `Questionnaire "${questionnaireId}" not found`
+                );
+            }
+        } catch (err) {
+            throw err;
+        }
+
+        return result.rows[0].modified;
+    }
+
+    async function updateQuestionnaireModifiedDate(questionnaireId) {
+        let result;
+
+        try {
+            result = await db.query(
+                'UPDATE questionnaire SET modified = current_timestamp WHERE id = $1',
+                [questionnaireId]
+            );
+            if (result.rowCount === 0) {
+                throw new VError(
+                    {
+                        name: 'UpdateNotSuccessful'
+                    },
+                    `Questionnaire "${questionnaireId}" modified date was not updated successfully`
+                );
+            }
+        } catch (err) {
+            throw err;
+        }
+
+        return result;
+    }
+
     return Object.freeze({
         createQuestionnaire,
         updateQuestionnaire,
         getQuestionnaire,
         getQuestionnaireSubmissionStatus,
         updateQuestionnaireSubmissionStatus,
-        getQuestionnaireIdsBySubmissionStatus
+        getQuestionnaireIdsBySubmissionStatus,
+        getQuestionnaireModifiedDate,
+        updateQuestionnaireModifiedDate
     });
 }
 

--- a/questionnaire/routes.js
+++ b/questionnaire/routes.js
@@ -212,4 +212,18 @@ router
         }
     });
 
+router
+    .route('/:questionnaireId/session/keep-alive')
+    .get(permissions('update:questionnaires'), async (req, res, next) => {
+        try {
+            const {questionnaireId} = req.params;
+            const questionnaireService = createQuestionnaireService({logger: req.log});
+            await questionnaireService.updateQuestionnaireModifiedDate(questionnaireId);
+            const sessionResource = await questionnaireService.getSessionResource(questionnaireId);
+            res.status(200).json(sessionResource);
+        } catch (err) {
+            next(err);
+        }
+    });
+
 module.exports = router;

--- a/questionnaire/routes.test.js
+++ b/questionnaire/routes.test.js
@@ -17,7 +17,8 @@ describe('/questionnaires/{questionnaireId}/progress-entries?filter[position]=cu
                 jest.doMock('./questionnaire-dal.js', () =>
                     // return a modified factory function, that returns an object with a method, that returns a valid created response
                     jest.fn(() => ({
-                        getQuestionnaire: () => mockResponse
+                        getQuestionnaire: () => mockResponse,
+                        getQuestionnaireModifiedDate: () => undefined
                     }))
                 );
 
@@ -103,7 +104,8 @@ describe('Answering and retrieving the next section', () => {
                     getQuestionnaire: () => mockQuestionnaire,
                     updateQuestionnaire: (id, updatedQuestionnaire) => {
                         mockQuestionnaire = updatedQuestionnaire;
-                    }
+                    },
+                    getQuestionnaireModifiedDate: () => undefined
                 }))
             );
 
@@ -162,7 +164,8 @@ describe('Issue: https://github.com/cdimascio/express-openapi-validator/issues/7
                 // return a modified factory function, that returns an object with a method, that returns a valid created response
                 jest.fn(() => ({
                     getQuestionnaire: () => mockResponse,
-                    updateQuestionnaire: () => undefined
+                    updateQuestionnaire: () => undefined,
+                    getQuestionnaireModifiedDate: () => undefined
                 }))
             );
 
@@ -179,7 +182,6 @@ describe('Issue: https://github.com/cdimascio/express-openapi-validator/issues/7
                     '/api/v1/questionnaires/285cb104-0c15-4a9c-9840-cb1007f098fb/progress-entries?page[before]=p--check-your-answers'
                 )
                 .set('Authorization', `Bearer ${tokens['read:progress-entries']}`);
-
             const previousSectionId = res.body.data[0].id;
 
             expect(previousSectionId).toEqual('p-applicant-enter-your-telephone-number');


### PR DESCRIPTION
* Add env var `DCS_SESSION_DURATION` - this now dictates session length for CW.
* Add endpoint `/questionnaires/{questionnaireId}/session/keep-alive` - refreshes session and returns session resource.
* Improve test coverage
* 
Proposed version bump: v6.1.0 (minor)