### PR TITLE
Audit fix jsonwebtoken

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -100,7 +100,7 @@ jobs:
           name: Authenticate and push image to ecr
           command: |
             echo "run aws"
-            $(aws ecr get-login --region eu-west-2 --no-include-email)
+            aws ecr get-login-password --region eu-west-2 | docker login --username AWS --password-stdin 754256621582.dkr.ecr.eu-west-2.amazonaws.com
 
             docker tag cica/cica-repo-dev:latest ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
             docker push ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
                 "lodash.merge": "^4.6.2",
                 "moment-timezone": "^0.5.33",
                 "morgan": "^1.9.1",
-                "notifications-node-client": "^5.1.0",
+                "notifications-node-client": "^6.0.0",
                 "pg": "^8.7.3",
                 "pino-http": "^5.5.0",
                 "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
@@ -4015,26 +4015,6 @@
                 "express": "^4.0.0"
             }
         },
-        "node_modules/express-jwt/node_modules/jsonwebtoken": {
-            "version": "9.0.0",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
-            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
-            "dependencies": {
-                "jws": "^3.2.2",
-                "lodash": "^4.17.21",
-                "ms": "^2.1.1",
-                "semver": "^7.3.8"
-            },
-            "engines": {
-                "node": ">=12",
-                "npm": ">=6"
-            }
-        },
-        "node_modules/express-jwt/node_modules/ms": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
         "node_modules/express-openapi-validator": {
             "version": "4.13.8",
             "resolved": "https://registry.npmjs.org/express-openapi-validator/-/express-openapi-validator-4.13.8.tgz",
@@ -6445,38 +6425,24 @@
             }
         },
         "node_modules/jsonwebtoken": {
-            "version": "8.5.1",
-            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-8.5.1.tgz",
-            "integrity": "sha512-XjwVfRS6jTMsqYs0EsuJ4LGxXV14zQybNd4L2r0UvbVnSF9Af8x7p5MzbJ90Ioz/9TI41/hTCvznF/loiSzn8w==",
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
             "dependencies": {
                 "jws": "^3.2.2",
-                "lodash.includes": "^4.3.0",
-                "lodash.isboolean": "^3.0.3",
-                "lodash.isinteger": "^4.0.4",
-                "lodash.isnumber": "^3.0.3",
-                "lodash.isplainobject": "^4.0.6",
-                "lodash.isstring": "^4.0.1",
-                "lodash.once": "^4.0.0",
+                "lodash": "^4.17.21",
                 "ms": "^2.1.1",
-                "semver": "^5.6.0"
+                "semver": "^7.3.8"
             },
             "engines": {
-                "node": ">=4",
-                "npm": ">=1.4.28"
+                "node": ">=12",
+                "npm": ">=6"
             }
         },
         "node_modules/jsonwebtoken/node_modules/ms": {
             "version": "2.1.3",
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
             "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
-        },
-        "node_modules/jsonwebtoken/node_modules/semver": {
-            "version": "5.7.1",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-            "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-            "bin": {
-                "semver": "bin/semver"
-            }
         },
         "node_modules/jwa": {
             "version": "1.4.1",
@@ -6697,45 +6663,10 @@
             "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
             "integrity": "sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk="
         },
-        "node_modules/lodash.includes": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/lodash.includes/-/lodash.includes-4.3.0.tgz",
-            "integrity": "sha1-YLuYqHy5I8aMoeUTJUgzFISfVT8="
-        },
-        "node_modules/lodash.isboolean": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isboolean/-/lodash.isboolean-3.0.3.tgz",
-            "integrity": "sha1-bC4XHbKiV82WgC/UOwGyDV9YcPY="
-        },
-        "node_modules/lodash.isinteger": {
-            "version": "4.0.4",
-            "resolved": "https://registry.npmjs.org/lodash.isinteger/-/lodash.isinteger-4.0.4.tgz",
-            "integrity": "sha1-YZwK89A/iwTDH1iChAt3sRzWg0M="
-        },
-        "node_modules/lodash.isnumber": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/lodash.isnumber/-/lodash.isnumber-3.0.3.tgz",
-            "integrity": "sha1-POdoEMWSjQM1IwGsKHMX8RwLH/w="
-        },
-        "node_modules/lodash.isplainobject": {
-            "version": "4.0.6",
-            "resolved": "https://registry.npmjs.org/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
-            "integrity": "sha1-fFJqUtibRcRcxpC4gWO+BJf1UMs="
-        },
-        "node_modules/lodash.isstring": {
-            "version": "4.0.1",
-            "resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-            "integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-        },
         "node_modules/lodash.merge": {
             "version": "4.6.2",
             "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
             "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ=="
-        },
-        "node_modules/lodash.once": {
-            "version": "4.1.1",
-            "resolved": "https://registry.npmjs.org/lodash.once/-/lodash.once-4.1.1.tgz",
-            "integrity": "sha1-DdOXEhPHxW34gJd9UEyI+0cal6w="
         },
         "node_modules/lodash.uniq": {
             "version": "4.5.0",
@@ -7492,13 +7423,16 @@
             }
         },
         "node_modules/notifications-node-client": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-5.1.1.tgz",
-            "integrity": "sha512-/Rutb/s7OLqIvsvgjPi6kVSu4nnEC5Hq1arB6fo219hAJOzkHJ+dJr1fMNIpDo7ubgf3hv5GFNzutPN54wIqOA==",
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/notifications-node-client/-/notifications-node-client-6.0.0.tgz",
+            "integrity": "sha512-QP4BSODBJROy2YU6sLHSx0uXKeINNyFcdMSHjczeffTMLlQ51SHrP+0n+UHMA0ta+gWuGGsjHfG3tpPtsZ1uNg==",
             "dependencies": {
                 "axios": "^0.25.0",
-                "jsonwebtoken": "^8.2.1",
-                "underscore": "^1.9.0"
+                "jsonwebtoken": "^9.0.0"
+            },
+            "engines": {
+                "node": ">=12.13.0",
+                "npm": ">=6.12.0"
             }
         },
         "node_modules/notifications-node-client/node_modules/axios": {
@@ -10368,11 +10302,6 @@
             "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
             "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
             "dev": true
-        },
-        "node_modules/underscore": {
-            "version": "1.13.3",
-            "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.3.tgz",
-            "integrity": "sha512-QvjkYpiD+dJJraRA8+dGAU4i7aBbb2s0S3jA45TFOvg2VgqvdCDd/3N6CqA8gluk1W91GLoXg5enMUx560QzuA=="
         },
         "node_modules/universalify": {
             "version": "0.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "6.2.4",
+    "version": "6.2.5",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "6.2.4",
+            "version": "6.2.5",
             "license": "MIT",
             "dependencies": {
                 "@netflix/nerror": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
                 "cookie-parser": "~1.4.3",
                 "debug": "~2.6.9",
                 "express": "^4.18.2",
-                "express-jwt": "^7.4.3",
+                "express-jwt": "^8.0.0",
                 "express-jwt-authz": "^2.4.1",
                 "express-openapi-validator": "^4.13.7",
                 "got": "^11.8.5",
@@ -1507,14 +1507,6 @@
                 "@types/node": "*",
                 "@types/qs": "*",
                 "@types/range-parser": "*"
-            }
-        },
-        "node_modules/@types/express-unless": {
-            "version": "0.5.3",
-            "resolved": "https://registry.npmjs.org/@types/express-unless/-/express-unless-0.5.3.tgz",
-            "integrity": "sha512-TyPLQaF6w8UlWdv4gj8i46B+INBVzURBNRahCozCSXfsK2VTlL1wNyTlMKw817VHygBtlcl5jfnPadlydr06Yw==",
-            "dependencies": {
-                "@types/express": "*"
             }
         },
         "node_modules/@types/graceful-fs": {
@@ -3999,14 +3991,13 @@
             }
         },
         "node_modules/express-jwt": {
-            "version": "7.7.1",
-            "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-7.7.1.tgz",
-            "integrity": "sha512-3x1Wv5ENeBLcBP5p3t42pFGxKCj8eyAdFiUSrvDExYtsXqYxh75dw5crpyXLXrDTDMPx50Uv9ODMQOl+ced57w==",
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/express-jwt/-/express-jwt-8.0.0.tgz",
+            "integrity": "sha512-c4xn5e40Ydu6hjfYSvixahPmwGAeBMLnSQ4V4lYPxnXbIQlh69UBF3sA2o+d3ePG2Uk7miYIfhV4OHz1wiaPrA==",
             "dependencies": {
-                "@types/express-unless": "^0.5.3",
                 "@types/jsonwebtoken": "^8.5.8",
-                "express-unless": "^1.0.0",
-                "jsonwebtoken": "^8.5.1"
+                "express-unless": "^2.1.3",
+                "jsonwebtoken": "^9.0.0"
             },
             "engines": {
                 "node": ">= 8.0.0"
@@ -4023,6 +4014,26 @@
                 "@types/express": "^4.0.0",
                 "express": "^4.0.0"
             }
+        },
+        "node_modules/express-jwt/node_modules/jsonwebtoken": {
+            "version": "9.0.0",
+            "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-9.0.0.tgz",
+            "integrity": "sha512-tuGfYXxkQGDPnLJ7SibiQgVgeDgfbPq2k2ICcbgqW8WxWLBAxKQM/ZCu/IT8SOSwmaYl4dpTFCW5xZv7YbbWUw==",
+            "dependencies": {
+                "jws": "^3.2.2",
+                "lodash": "^4.17.21",
+                "ms": "^2.1.1",
+                "semver": "^7.3.8"
+            },
+            "engines": {
+                "node": ">=12",
+                "npm": ">=6"
+            }
+        },
+        "node_modules/express-jwt/node_modules/ms": {
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+            "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node_modules/express-openapi-validator": {
             "version": "4.13.8",
@@ -4060,9 +4071,9 @@
             "integrity": "sha512-JLyh7xT1kizaEvcaXOQwOc2/Yhw6KZOvPf1S8401UyLk86CU79LN3vl7ztXGm/pZ+YjoyAJ4rxmHwbkBXJX+yw=="
         },
         "node_modules/express-unless": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-1.0.0.tgz",
-            "integrity": "sha512-zXSSClWBPfcSYjg0hcQNompkFN/MxQQ53eyrzm9BYgik2ut2I7PxAf2foVqBRMYCwWaZx/aWodi+uk76npdSAw=="
+            "version": "2.1.3",
+            "resolved": "https://registry.npmjs.org/express-unless/-/express-unless-2.1.3.tgz",
+            "integrity": "sha512-wj4tLMyCVYuIIKHGt0FhCtIViBcwzWejX0EjNxveAa6dG+0XBCQhMbx+PnkLkFCxLC69qoFrxds4pIyL88inaQ=="
         },
         "node_modules/express/node_modules/cookie": {
             "version": "0.5.0",
@@ -6840,7 +6851,6 @@
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
             "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-            "dev": true,
             "dependencies": {
                 "yallist": "^4.0.0"
             },
@@ -9007,10 +9017,9 @@
             "dev": true
         },
         "node_modules/semver": {
-            "version": "7.3.7",
-            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.7.tgz",
-            "integrity": "sha512-QlYTucUYOews+WeEujDoEGziz4K6c47V/Bd+LjSSYcA94p+DmINdf7ncaUinThfvZyu13lN9OY1XDxt8C0Tw0g==",
-            "dev": true,
+            "version": "7.3.8",
+            "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
+            "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
             "dependencies": {
                 "lru-cache": "^6.0.0"
             },
@@ -10675,8 +10684,7 @@
         "node_modules/yallist": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
-            "dev": true
+            "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
         },
         "node_modules/yaml": {
             "version": "1.10.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7105,9 +7105,9 @@
             }
         },
         "node_modules/moment-timezone": {
-            "version": "0.5.34",
-            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.34.tgz",
-            "integrity": "sha512-3zAEHh2hKUs3EXLESx/wsgw6IQdusOT8Bxm3D9UrHPQR7zlMmzwybC8zHEM1tQ4LJwP7fcxrWr8tuBg05fFCbg==",
+            "version": "0.5.40",
+            "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.40.tgz",
+            "integrity": "sha512-tWfmNkRYmBkPJz5mr9GVDn9vRlVZOTe6yqY92rFxiOdWXbjaR0+9LwQnZGGuNR63X456NqmEkbskte8tWL5ePg==",
             "dependencies": {
                 "moment": ">= 2.9.0"
             },

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
         "lodash.merge": "^4.6.2",
         "moment-timezone": "^0.5.33",
         "morgan": "^1.9.1",
-        "notifications-node-client": "^5.1.0",
+        "notifications-node-client": "^6.0.0",
         "pg": "^8.7.3",
         "pino-http": "^5.5.0",
         "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "cookie-parser": "~1.4.3",
         "debug": "~2.6.9",
         "express": "^4.18.2",
-        "express-jwt": "^7.4.3",
+        "express-jwt": "^8.0.0",
         "express-jwt-authz": "^2.4.1",
         "express-openapi-validator": "^4.13.7",
         "got": "^11.8.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "6.2.4",
+    "version": "6.2.5",
     "engines": {
         "npm": ">=8.5.2",
         "node": ">=16.0.0"


### PR DESCRIPTION
- replaced deprecated aws client get-login method with get-login-password see [login to the repository](https://user-guide.cloud-platform.service.justice.gov.uk/documentation/deploying-an-app/helloworld-app-deploy.html#login-to-the-repository)
- bump moment-timezone to 0.5.40 due to Command Injection in moment-timezone - https://github.com/advisories/GHSA-56x4-j7p9-fcf9

Audit fixes for jsonwebtoken has insecure input validation in jwt.verify function - https://github.com/advisories/GHSA-27h2-hvpr-p74q
- bump express-jwt to 8.0.0 
- bump notifications-node-client to 6.0.0