### PR TITLE
Auto build OpenAPI when committing changes to src files

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -3,6 +3,9 @@ const config = {
     '*.{json,yml,yaml}': ['prettier --write']
 };
 
+// Rebuild the OpenAPI spec any time the src files are changed
+config['./openapi/src/**/*.{js,json}'] = ['npm run openapi:build'];
+
 config['./openapi/*.json'] = ['speccy lint ./openapi/openapi.json'];
 
 module.exports = config;

--- a/openapi/src/dereference-openapi.js
+++ b/openapi/src/dereference-openapi.js
@@ -3,11 +3,20 @@
 // eslint-disable-next-line import/no-extraneous-dependencies
 const $RefParser = require('json-schema-ref-parser');
 const fs = require('fs');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const prettier = require('prettier');
+const conf = require('../../.prettierrc.js');
 
 (async () => {
     const dereferencedContract = await $RefParser.dereference('openapi/openapi.json');
+    const contractJson = JSON.stringify(dereferencedContract, null, 4);
+    const formattedContractJson = prettier.format(contractJson, {
+        ...conf,
+        parser: 'json',
+        endOfLine: 'crlf'
+    });
 
-    fs.writeFile('openapi/openapi.json', JSON.stringify(dereferencedContract, null, 4), err => {
+    fs.writeFile('openapi/openapi.json', formattedContractJson, err => {
         // throws an error, you could also catch it here
         if (err) {
             throw err;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "7.1.0",
+            "version": "7.1.1",
             "license": "MIT",
             "dependencies": {
                 "@netflix/nerror": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "7.1.0",
+    "version": "7.1.1",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.0.0"


### PR DESCRIPTION
Currently, building the OpenAPI is a manual step before committing. Recent PRs that have involved making changes to the OpenAPI src files have missed this step. There are a number of upcoming OpenAPI PRs which will benefit from this.  

This PR also runs the OpenAPI document through prettier to prevent Git from detecting a file change due to formatting/whitespace.