### PR TITLE
Serve V1 & V2 OpenAPI specs via Swagger UI

### DIFF
--- a/docs/routes.js
+++ b/docs/routes.js
@@ -13,6 +13,7 @@ router.use('/openapi-v2.json', express.static(path.join(__dirname, '../openapi/o
 const swaggerUiOptions = {
     explorer: true,
     swaggerOptions: {
+        validatorUrl: null,
         urls: [
             {
                 url: '/docs/openapi.json',

--- a/docs/routes.js
+++ b/docs/routes.js
@@ -2,14 +2,31 @@
 
 const express = require('express');
 const swaggerUi = require('swagger-ui-express');
-
-const swaggerDocument = require('../openapi/openapi.json');
+const path = require('path');
 
 const router = express.Router();
 
-// Ensure JWT is valid
-// router.use(validateJWT({secret: process.env.SECRET}));
+// Server OpenAPI specs to allow Swagger UI to switch between definitions
+router.use('/openapi.json', express.static(path.join(__dirname, '../openapi/openapi.json')));
+router.use('/openapi-v2.json', express.static(path.join(__dirname, '../openapi/openapi-v2.json')));
+
+const swaggerUiOptions = {
+    explorer: true,
+    swaggerOptions: {
+        urls: [
+            {
+                url: '/docs/openapi.json',
+                name: 'Spec V1'
+            },
+            {
+                url: '/docs/openapi-v2.json',
+                name: 'Spec V2'
+            }
+        ]
+    }
+};
+
 router.use('/', swaggerUi.serve);
-router.get('/', swaggerUi.setup(swaggerDocument));
+router.get('/', swaggerUi.setup(null, swaggerUiOptions));
 
 module.exports = router;

--- a/openapi/openapi-v2.json
+++ b/openapi/openapi-v2.json
@@ -1,0 +1,26 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Data Capture Service API",
+        "description": "Manage a questionnaire lifecycle",
+        "version": "2.0.0",
+        "license": {
+            "name": "MIT"
+        },
+        "contact": {
+            "name": "API Support",
+            "email": "api@cica.gov.uk"
+        }
+    },
+    "servers": [
+        {
+            "url": "/api"
+        }
+    ],
+    "tags": [
+        {
+            "name": "Questionnaires"
+        }
+    ],
+    "paths": {}
+}

--- a/openapi/src/dereference-openapi-v2.js
+++ b/openapi/src/dereference-openapi-v2.js
@@ -1,0 +1,29 @@
+'use strict';
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const $RefParser = require('json-schema-ref-parser');
+const fs = require('fs');
+// eslint-disable-next-line import/no-extraneous-dependencies
+const prettier = require('prettier');
+const conf = require('../../.prettierrc.js');
+
+(async () => {
+    const dereferencedContract = await $RefParser.dereference('openapi/openapi-v2.json');
+    const contractJson = JSON.stringify(dereferencedContract, null, 4);
+    const formattedContractJson = prettier.format(contractJson, {
+        ...conf,
+        parser: 'json',
+        endOfLine: 'crlf'
+    });
+
+    fs.writeFile('openapi/openapi-v2.json', formattedContractJson, err => {
+        // throws an error, you could also catch it here
+        if (err) {
+            throw err;
+        }
+
+        // success case, the file was saved
+        // eslint-disable-next-line
+        console.log('V2 dereferenced contract saved');
+    });
+})();

--- a/openapi/src/openapi-src-v2.json
+++ b/openapi/src/openapi-src-v2.json
@@ -1,0 +1,22 @@
+{
+    "openapi": "3.0.2",
+    "info": {
+        "title": "Data Capture Service API",
+        "description": "Manage a questionnaire lifecycle",
+        "version": "2.0.0",
+        "license": {
+            "name": "MIT"
+        },
+        "contact": {
+            "name": "API Support",
+            "email": "api@cica.gov.uk"
+        }
+    },
+    "servers": [
+        {
+            "url": "/api"
+        }
+    ],
+    "tags": [{"name": "Questionnaires"}],
+    "paths": {}
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "7.1.1",
+            "version": "7.2.0",
             "license": "MIT",
             "dependencies": {
                 "@netflix/nerror": "^1.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
                 "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
                 "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v10.0.3",
-                "swagger-ui-express": "^4.3.0",
+                "swagger-ui-express": "^4.6.3",
                 "uuid": "^3.3.2",
                 "verror": "^1.10.0"
             },
@@ -9826,14 +9826,14 @@
             }
         },
         "node_modules/swagger-ui-dist": {
-            "version": "4.11.1",
-            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.11.1.tgz",
-            "integrity": "sha512-pf3kfSTYdF9mYFY2VnfJ51wnXlSVhEGdtymhpHzfbFw2jTbiEWgBoVz5EB9aW2EaJvUGTM1YHAXYZX7Jk4RdAQ=="
+            "version": "4.18.3",
+            "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.18.3.tgz",
+            "integrity": "sha512-QW280Uvt234+TLo9NMPRa2Sj17RoorbQlR2eEY4R6Cs0LbdXhiO14YWX9OPBkBdiN64GQYz4zU8wlHLVi81lBg=="
         },
         "node_modules/swagger-ui-express": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.4.0.tgz",
-            "integrity": "sha512-1CzRkHG386VQMVZK406jcpgnW2a9A5A/NiAjKhsFTQqUBWRF+uGbXTU/mA7WSV3mTzyOQDvjBdWP/c2qd5lqKw==",
+            "version": "4.6.3",
+            "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.6.3.tgz",
+            "integrity": "sha512-CDje4PndhTD2HkgyKH3pab+LKspDeB/NhPN2OF1j+piYIamQqBYwAXWESOT1Yju2xFg51bRW9sUng2WxDjzArw==",
             "dependencies": {
                 "swagger-ui-dist": ">=4.11.0"
             },
@@ -9841,7 +9841,7 @@
                 "node": ">= v0.10.32"
             },
             "peerDependencies": {
-                "express": ">=4.0.0"
+                "express": ">=4.0.0 || >=5.0.0-beta"
             }
         },
         "node_modules/swagger2openapi": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "7.1.1",
+    "version": "7.2.0",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "scripts": {
         "start": "node ./bin/www",
         "start:dev": "nodemon -L -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run:dev",
-        "openapi:build": "speccy lint openapi/src/openapi-src.json -j && speccy resolve ./openapi/src/openapi-src.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi.json && node ./openapi/src/dereference-openapi.js",
+        "openapi:build-v1": "speccy lint openapi/src/openapi-src.json -j && speccy resolve ./openapi/src/openapi-src.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi.json && node ./openapi/src/dereference-openapi.js",
+        "openapi:build-v2": "speccy lint openapi/src/openapi-src-v2.json -j && speccy resolve ./openapi/src/openapi-src-v2.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi-v2.json && node ./openapi/src/dereference-openapi-v2.js",
+        "openapi:build": "npm run openapi:build-v1 && npm run openapi:build-v2",
         "build:run:dev": "npm run openapi:build && node --inspect=0.0.0.0:9229 ./bin/www",
         "pretestx": "eslint .",
         "test": "jest",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
         "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
         "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v10.0.3",
-        "swagger-ui-express": "^4.3.0",
+        "swagger-ui-express": "^4.6.3",
         "uuid": "^3.3.2",
         "verror": "^1.10.0"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     },
     "scripts": {
         "start": "node ./bin/www",
-        "start:dev": "nodemon -L -e .js,.json,.njk,.yml --ignore openapi/openapi.json --exec npm run build:run:dev",
+        "start:dev": "nodemon -L -e .js,.json,.njk,.yml --ignore openapi/openapi.json --ignore openapi/openapi-v2.json --exec npm run build:run:dev",
         "openapi:build-v1": "speccy lint openapi/src/openapi-src.json -j && speccy resolve ./openapi/src/openapi-src.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi.json && node ./openapi/src/dereference-openapi.js",
         "openapi:build-v2": "speccy lint openapi/src/openapi-src-v2.json -j && speccy resolve ./openapi/src/openapi-src-v2.json -j | yaml2json --pretty --indentation 4 --save - > ./openapi/openapi-v2.json && node ./openapi/src/dereference-openapi-v2.js",
         "openapi:build": "npm run openapi:build-v1 && npm run openapi:build-v2",


### PR DESCRIPTION
This adds the initial V2 OpenAPI spec and supporting scripts in generating that spec.

It also updates the Swagger UI config to allow both versions of the spec to be viewed at runtime.