### PR TITLE
Dcs deploy to uat

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ jobs:
             docker tag cica/cica-repo-dev:latest ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
             docker push ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
 
-            if [ "${CIRCLE_BRANCH}" ==  "dcs-deploy" ]; then
+            if [["${CIRCLE_BRANCH}" ==  "dcs-deploy" || "${CIRCLE_BRANCH}" ==  "dcs-deploy-to-uat"]]; then
                docker tag cica/cica-repo-dev:latest ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
                docker push ${ECR_REPOSITORY}/cica/cica-repo-dev:${CIRCLE_SHA1}
             fi
@@ -209,37 +209,47 @@ workflows:
             - publish_latest
           filters:
             branches:
-              only: dcs-deploy
-      - deploy_to_dev:
+              only:
+                - dcs-deploy
+                - dcs-deploy-to-uat
+      - deploy_to_uat_approval:
+            type: approval
+            requires:
+             - push_image
+            filters:
+              branches:
+               only: dcs-deploy-to-uat
+      - deploy_to_uat:
           requires:
-            - push_image
+            - deploy_to_uat_approval
           filters:
             branches:
-              only: dcs-deploy
-      - deploy_to_uat_approval:
-          type: approval
+              only: dcs-deploy-to-uat
+      - deploy_to_dev_approval:
+            type: approval
+            requires:
+             - push_image
+            filters:
+              branches:
+               only: dcs-deploy
+      - deploy_to_dev:
           requires:
-            - push_image
-            - deploy_to_dev
-      - deploy_to_uat:
-          #          type: approval
-          requires:
-            - push_image
-            - deploy_to_uat_approval
+            - deploy_to_dev_approval
           filters:
             branches:
               only: dcs-deploy
       - deploy_to_prod_approval:
           type: approval
           requires:
-            - push_image
-            - deploy_to_uat
+            - deploy_to_dev
           filters:
             branches:
-              only: dcs-deploy
+              only:
+                - dcs-deploy
       - deploy_to_prod:
           requires:
             - deploy_to_prod_approval
           filters:
             branches:
-              only: dcs-deploy
+              only:
+                - dcs-deploy


### PR DESCRIPTION
Merge to master and leave branch as feature branch for deployments.

Creates two pipelines to be controlled via bash scripst:
1) deploy dcs to dev then on approval to prod. On dcs-deploy branch
2) deploy dcs to uat. On dcs-deploy-to-uat branch

No path from uat to prod

Both pipelines tested and can be viewed:
https://app.circleci.com/pipelines/github/CriminalInjuriesCompensationAuthority/data-capture-service/2580/workflows/43cf7910-324c-4af9-8c98-c2199da6c3a8
For uat
https://app.circleci.com/pipelines/github/CriminalInjuriesCompensationAuthority/data-capture-service/2581/workflows/3aca3844-efbb-4b39-b90a-4e41ead586be
For dev-prod
