### PR TITLE
Fix/max length care order authority

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "8.2.3",
+    "version": "8.2.4",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "8.2.3",
+            "version": "8.2.4",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.345.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
                 "pino-http": "^5.5.0",
                 "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
                 "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
-                "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.11",
+                "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.12",
                 "semver": "^7.5.4",
                 "swagger-ui-express": "^4.6.3",
                 "uuid": "^3.3.2",
@@ -11890,8 +11890,8 @@
             }
         },
         "node_modules/q-templates-application": {
-            "version": "12.0.11",
-            "resolved": "git+ssh://git@github.com/CriminalInjuriesCompensationAuthority/q-templates-application.git#a7a148d391d486c69b9b3f857d15b5fb63e6ccc2",
+            "version": "12.0.12",
+            "resolved": "git+ssh://git@github.com/CriminalInjuriesCompensationAuthority/q-templates-application.git#aa472aaa3b5801a165f2b2903a0c42cf7a6cf4c9",
             "license": "MIT",
             "engines": {
                 "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
         "pino-http": "^5.5.0",
         "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
         "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
-        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.11",
+        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.12",
         "semver": "^7.5.4",
         "swagger-ui-express": "^4.6.3",
         "uuid": "^3.3.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "8.2.3",
+    "version": "8.2.4",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"


### PR DESCRIPTION
technically a breaking change
but we are going to go ahead and patch and deal with any saved applications that have characters > 50 which are then submitted. (They will appear on the tempus DLQ).
If someone goes back to the question with > 50 chars they will encounter a validation error.