### PR TITLE
Move UI schema properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "data-capture-service",
-    "version": "9.4.0",
+    "version": "9.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "data-capture-service",
-            "version": "9.4.0",
+            "version": "9.5.0",
             "license": "MIT",
             "dependencies": {
                 "@aws-sdk/client-s3": "^3.345.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
                 "pino-std-serializers": "^6.2.2",
                 "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
                 "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
-                "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.22",
+                "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.1.0",
                 "semver": "^7.5.4",
                 "swagger-ui-express": "^4.6.3",
                 "uuid": "^3.3.2",
@@ -11820,8 +11820,8 @@
             }
         },
         "node_modules/q-templates-application": {
-            "version": "12.0.22",
-            "resolved": "git+ssh://git@github.com/CriminalInjuriesCompensationAuthority/q-templates-application.git#1b3a3b4401a9a2dd35931af1c81b0148f864d44a",
+            "version": "12.1.0",
+            "resolved": "git+ssh://git@github.com/CriminalInjuriesCompensationAuthority/q-templates-application.git#67485de3f5bc72a02d495b09f3bc79a43e3a35b0",
             "license": "MIT",
             "engines": {
                 "node": ">=16.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "9.4.0",
+    "version": "9.5.0",
     "engines": {
         "npm": ">=9.5.0",
         "node": ">=18.16.1"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "pino-std-serializers": "^6.2.2",
         "q-expressions": "github:CriminalInjuriesCompensationAuthority/q-expressions",
         "q-router": "github:CriminalInjuriesCompensationAuthority/q-router#v3.0.2",
-        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.0.22",
+        "q-templates-application": "github:CriminalInjuriesCompensationAuthority/q-templates-application#v12.1.0",
         "semver": "^7.5.4",
         "swagger-ui-express": "^4.6.3",
         "uuid": "^3.3.2",

--- a/questionnaire/questionnaire/questionnaire.js
+++ b/questionnaire/questionnaire/questionnaire.js
@@ -10,6 +10,7 @@ defaults.getValueContextualiser = require('./utils/getValueContextualiser');
 defaults.deepClone = require('./utils/deepCloneJsonDerivedObject');
 defaults.getJsonExpressionEvaluator = require('./utils/getJsonExpressionEvaluator');
 defaults.qExpression = require('q-expressions');
+defaults.sortThemedAnswers = require('./utils/sortThemedAnswers');
 
 function createQuestionnaire({
     questionnaireDefinition,
@@ -21,7 +22,8 @@ function createQuestionnaire({
     getValueContextualiser = defaults.getValueContextualiser,
     deepClone = defaults.deepClone,
     getJsonExpressionEvaluator = defaults.getJsonExpressionEvaluator,
-    qExpression = defaults.qExpression
+    qExpression = defaults.qExpression,
+    sortThemedAnswers = defaults.sortThemedAnswers
 }) {
     function getId() {
         return questionnaireDefinition.id;
@@ -250,6 +252,15 @@ function createQuestionnaire({
 
         if (sectionDefinitionVars !== undefined && allowSummary === true) {
             const resolvedVars = getResolvedVars(sectionId, sectionDefinitionVars);
+            if (resolvedVars.summary) {
+                if (sectionDefinition.schema.options) {
+                    const sortingInstructions = sectionDefinition.schema.options.ordering;
+                    resolvedVars.summary = sortThemedAnswers(
+                        resolvedVars.summary,
+                        sortingInstructions
+                    );
+                }
+            }
             const valueVarReplacer = getValueVarReplacer(resolvedVars);
 
             orderedValueTransformers.push(valueVarReplacer);

--- a/questionnaire/questionnaire/questionnaire.test.js
+++ b/questionnaire/questionnaire/questionnaire.test.js
@@ -275,6 +275,148 @@ const questionnaireDefinition = {
                 ]
             }
         },
+        'p-applicant-have-you-been-known-by-any-other-names': {
+            schema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                type: 'object',
+                propertyNames: {
+                    enum: [
+                        'q-applicant-have-you-been-known-by-any-other-names',
+                        'q-applicant-what-other-names-have-you-used'
+                    ]
+                },
+                required: ['q-applicant-have-you-been-known-by-any-other-names'],
+                additionalProperties: false,
+                properties: {
+                    'q-applicant-have-you-been-known-by-any-other-names': {
+                        type: 'boolean',
+                        title: 'Have you been known by any other names?',
+                        oneOf: [
+                            {
+                                title: 'Yes',
+                                const: true
+                            },
+                            {
+                                title: 'No',
+                                const: false
+                            }
+                        ],
+                        meta: {
+                            classifications: {
+                                theme: 'applicant-details'
+                            },
+                            summary: {
+                                title: 'Have you been known by any other names?'
+                            }
+                        }
+                    },
+                    'q-applicant-what-other-names-have-you-used': {
+                        type: 'string',
+                        title: 'What other names have you been known by?',
+                        maxLength: 50,
+                        errorMessage: {
+                            maxLength: 'Other names must be less than 50 characters'
+                        },
+                        meta: {
+                            classifications: {
+                                theme: 'applicant-details'
+                            }
+                        }
+                    }
+                },
+                allOf: [
+                    {
+                        $ref: '#/definitions/if-yes-then-q-what-other-names-is-required'
+                    }
+                ],
+                definitions: {
+                    'if-yes-then-q-what-other-names-is-required': {
+                        if: {
+                            properties: {
+                                'q-applicant-have-you-been-known-by-any-other-names': {
+                                    const: true
+                                }
+                            },
+                            required: ['q-applicant-have-you-been-known-by-any-other-names']
+                        },
+                        then: {
+                            required: ['q-applicant-what-other-names-have-you-used'],
+                            propertyNames: {
+                                enum: [
+                                    'q-applicant-have-you-been-known-by-any-other-names',
+                                    'q-applicant-what-other-names-have-you-used'
+                                ]
+                            },
+                            errorMessage: {
+                                required: {
+                                    'q-applicant-what-other-names-have-you-used':
+                                        'Other names must be less than 50 characters'
+                                }
+                            }
+                        },
+                        else: {
+                            required: ['q-applicant-have-you-been-known-by-any-other-names']
+                        }
+                    }
+                },
+                errorMessage: {
+                    required: {
+                        'q-applicant-have-you-been-known-by-any-other-names':
+                            'Enter any other names you have been known by'
+                    }
+                },
+                examples: [
+                    {
+                        'q-applicant-have-you-been-known-by-any-other-names': true,
+                        'q-applicant-what-other-names-have-you-used': 'Mr Biz Baz'
+                    },
+                    {
+                        'q-applicant-have-you-been-known-by-any-other-names': false
+                    }
+                ],
+                invalidExamples: [
+                    {
+                        'q-applicant-have-you-been-known-by-any-other-names': 'foo'
+                    },
+                    {
+                        'q-applicant-what-other-names-have-you-used': 'Mr Biz Baz'
+                    },
+                    {
+                        'q-applicant-have-you-been-known-by-any-other-names': true,
+                        'q-applicant-what-other-names-have-you-used': null
+                    }
+                ],
+                options: {
+                    transformOrder: [
+                        'q-applicant-what-other-names-have-you-used',
+                        'q-applicant-have-you-been-known-by-any-other-names'
+                    ],
+                    outputOrder: ['q-applicant-have-you-been-known-by-any-other-names'],
+                    properties: {
+                        'q-applicant-have-you-been-known-by-any-other-names': {
+                            options: {
+                                macroOptions: {
+                                    classes: 'govuk-radios'
+                                },
+                                conditionalComponentMap: [
+                                    {
+                                        itemValue: true,
+                                        componentIds: ['q-applicant-what-other-names-have-you-used']
+                                    }
+                                ]
+                            }
+                        },
+                        'q-applicant-what-other-names-have-you-used': {
+                            options: {
+                                macroOptions: {
+                                    classes: 'govuk-input--width-20'
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
         'p-mainapplicant-name': {
             l10n: {
                 vars: {
@@ -454,6 +596,13 @@ const questionnaireDefinition = {
                             }
                         }
                     }
+                },
+                options: {
+                    ordering: {
+                        'q-applicant-have-you-been-known-by-any-other-names': [
+                            'q-applicant-what-other-names-have-you-used'
+                        ]
+                    }
                 }
             }
         },
@@ -523,6 +672,7 @@ const questionnaireDefinition = {
         'p-applicant-enter-your-email-address',
         'p-applicant-who-are-you-applying-for',
         'p-applicant-enter-your-name',
+        'p-applicant-have-you-been-known-by-any-other-names',
         'p-applicant-british-citizen-or-eu-national',
         'p-applicant-theme-undefined',
         'p-applicant-theme-not-found',
@@ -544,6 +694,10 @@ const questionnaireDefinition = {
             'q-applicant-title': 'Mr',
             'q-applicant-first-name': 'Foo',
             'q-applicant-last-name': 'Bar'
+        },
+        'p-applicant-have-you-been-known-by-any-other-names': {
+            'q-applicant-have-you-been-known-by-any-other-names': true,
+            'q-applicant-what-other-names-have-you-used': 'Mr Test Testcase'
         },
         'p-applicant-british-citizen-or-eu-national': {
             'q-applicant-british-citizen-or-eu-national': true
@@ -802,7 +956,7 @@ describe('Questionnaire', () => {
     });
 
     describe('Given a section definition requiring an answer summary', () => {
-        it('should return a section containing an answer summary', () => {
+        it('should return a section containing a correctly ordered answer summary', () => {
             const questionnaire = createQuestionnaire({questionnaireDefinition});
             const section = questionnaire.getSection('p--check-your-answers');
             const sectionSchema = section.getSchema();
@@ -881,6 +1035,26 @@ describe('Questionnaire', () => {
                                                 theme: 'applicant-details'
                                             },
                                             {
+                                                id:
+                                                    'q-applicant-have-you-been-known-by-any-other-names',
+                                                type: 'simple',
+                                                label: 'Have you been known by any other names?',
+                                                value: true,
+                                                valueLabel: 'Yes',
+                                                sectionId:
+                                                    'p-applicant-have-you-been-known-by-any-other-names',
+                                                theme: 'applicant-details'
+                                            },
+                                            {
+                                                id: 'q-applicant-what-other-names-have-you-used',
+                                                type: 'simple',
+                                                label: 'What other names have you been known by?',
+                                                value: 'Mr Test Testcase',
+                                                sectionId:
+                                                    'p-applicant-have-you-been-known-by-any-other-names',
+                                                theme: 'applicant-details'
+                                            },
+                                            {
                                                 id: 'q-applicant-british-citizen-or-eu-national',
                                                 type: 'simple',
                                                 label:
@@ -940,6 +1114,13 @@ describe('Questionnaire', () => {
                                 }
                             }
                         }
+                    }
+                },
+                options: {
+                    ordering: {
+                        'q-applicant-have-you-been-known-by-any-other-names': [
+                            'q-applicant-what-other-names-have-you-used'
+                        ]
                     }
                 }
             });

--- a/questionnaire/questionnaire/utils/sortThemedAnswers/index.js
+++ b/questionnaire/questionnaire/utils/sortThemedAnswers/index.js
@@ -1,0 +1,37 @@
+'use strict';
+
+function getDependentQuestionIds(questionId, sortingInstructions) {
+    const questionOrdering = sortingInstructions[questionId];
+    return questionOrdering || [];
+}
+
+function dependentsInIncorrectOrder(values, valueIndex, sortingInstructions) {
+    if (valueIndex === 0) {
+        return false;
+    }
+    const currentQuestionId = values[valueIndex].id;
+    const previousQuestionId = values[valueIndex - 1].id;
+    const dependentIds = getDependentQuestionIds(currentQuestionId, sortingInstructions);
+    return dependentIds.includes(previousQuestionId);
+}
+
+function sortThemedAnswers(themeContent, sortingInstructions) {
+    themeContent.forEach(theme => {
+        if (theme.type === 'theme') {
+            const values = theme.values || [];
+            if (values.length > 0) {
+                values.forEach((value, valueIndex) => {
+                    if (dependentsInIncorrectOrder(values, valueIndex, sortingInstructions)) {
+                        [values[valueIndex], values[valueIndex - 1]] = [
+                            values[valueIndex - 1],
+                            values[valueIndex]
+                        ];
+                    }
+                });
+            }
+        }
+    });
+    return themeContent;
+}
+
+module.exports = sortThemedAnswers;

--- a/questionnaire/questionnaire/utils/sortThemedAnswers/index.test.js
+++ b/questionnaire/questionnaire/utils/sortThemedAnswers/index.test.js
@@ -1,0 +1,271 @@
+'use strict';
+
+const sortThemedAnswers = require('./index');
+
+describe('sort-themed-answers', () => {
+    it('should reorder a themed summary according to provided instructions', () => {
+        const orderingInstructions = {
+            'q-applicant-have-you-been-known-by-any-other-names': [
+                'q-applicant-what-other-names-have-you-used'
+            ]
+        };
+        const themedAnswers = [
+            {
+                type: 'theme',
+                id: 'applicant-details',
+                title: 'Your details',
+                values: [
+                    {
+                        id: 'q-applicant-date-of-birth',
+                        type: 'simple',
+                        label: 'Date of birth',
+                        value: '1970-01-01T00:00:00.000Z',
+                        sectionId: 'p-applicant-date-of-birth',
+                        theme: 'applicant-details',
+                        format: {
+                            precision: 'YYYY-MM-DD',
+                            value: 'date-time'
+                        }
+                    },
+                    {
+                        id: 'q-applicant-who-are-you-applying-for',
+                        type: 'simple',
+                        label: 'Who are you applying for?',
+                        sectionId: 'p-applicant-who-are-you-applying-for',
+                        theme: 'applicant-details',
+                        value: 'myself',
+                        valueLabel: 'Myself'
+                    },
+                    {
+                        id: 'applicant-name',
+                        type: 'composite',
+                        label: 'Your name',
+                        values: [
+                            {
+                                id: 'q-applicant-title',
+                                type: 'simple',
+                                label: 'Title',
+                                value: 'Mr',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            },
+                            {
+                                id: 'q-applicant-first-name',
+                                type: 'simple',
+                                label: 'First name',
+                                value: 'Foo',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            },
+                            {
+                                id: 'q-applicant-last-name',
+                                type: 'simple',
+                                label: 'Last name',
+                                value: 'Bar',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            }
+                        ],
+                        sectionId: 'p-applicant-enter-your-name',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-what-other-names-have-you-used',
+                        type: 'simple',
+                        label: 'What other names have you been known by?',
+                        value: 'Mr Test Testcase',
+                        sectionId: 'p-applicant-have-you-been-known-by-any-other-names',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-have-you-been-known-by-any-other-names',
+                        type: 'simple',
+                        label: 'Have you been known by any other names?',
+                        value: true,
+                        valueLabel: 'Yes',
+                        sectionId: 'p-applicant-have-you-been-known-by-any-other-names',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-british-citizen-or-eu-national',
+                        type: 'simple',
+                        label: 'Mr Foo Bar, are you a British citizen or EU national?',
+                        value: true,
+                        valueLabel: 'Yes',
+                        sectionId: 'p-applicant-british-citizen-or-eu-national',
+                        theme: 'applicant-details'
+                    }
+                ]
+            },
+            {
+                type: 'theme',
+                id: 'contact-details',
+                title: 'Contact details',
+                values: [
+                    {
+                        id: 'q-applicant-enter-your-email-address',
+                        type: 'simple',
+                        label: 'Enter your email address',
+                        value: 'bar@9f7b855e-586b-49f0-ac7a-026919732b06.gov.uk',
+                        sectionId: 'p-applicant-enter-your-email-address',
+                        theme: 'contact-details',
+                        format: {
+                            value: 'email'
+                        }
+                    }
+                ]
+            },
+            {
+                type: 'theme',
+                id: 'default',
+                title: 'Answers',
+                values: [
+                    {
+                        id: 'q-applicant-theme-undefined',
+                        type: 'simple',
+                        label: 'Enter your fav colour',
+                        value: 'red',
+                        sectionId: 'p-applicant-theme-undefined'
+                    },
+                    {
+                        id: 'q-applicant-theme-not-found',
+                        type: 'simple',
+                        label: 'Enter your fav colour',
+                        value: 'blue',
+                        sectionId: 'p-applicant-theme-not-found',
+                        theme: 'this-theme-is-not-found'
+                    }
+                ]
+            }
+        ];
+        expect(sortThemedAnswers(themedAnswers, orderingInstructions)).toEqual([
+            {
+                type: 'theme',
+                id: 'applicant-details',
+                title: 'Your details',
+                values: [
+                    {
+                        id: 'q-applicant-date-of-birth',
+                        type: 'simple',
+                        label: 'Date of birth',
+                        value: '1970-01-01T00:00:00.000Z',
+                        sectionId: 'p-applicant-date-of-birth',
+                        theme: 'applicant-details',
+                        format: {
+                            precision: 'YYYY-MM-DD',
+                            value: 'date-time'
+                        }
+                    },
+                    {
+                        id: 'q-applicant-who-are-you-applying-for',
+                        type: 'simple',
+                        label: 'Who are you applying for?',
+                        sectionId: 'p-applicant-who-are-you-applying-for',
+                        theme: 'applicant-details',
+                        value: 'myself',
+                        valueLabel: 'Myself'
+                    },
+                    {
+                        id: 'applicant-name',
+                        type: 'composite',
+                        label: 'Your name',
+                        values: [
+                            {
+                                id: 'q-applicant-title',
+                                type: 'simple',
+                                label: 'Title',
+                                value: 'Mr',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            },
+                            {
+                                id: 'q-applicant-first-name',
+                                type: 'simple',
+                                label: 'First name',
+                                value: 'Foo',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            },
+                            {
+                                id: 'q-applicant-last-name',
+                                type: 'simple',
+                                label: 'Last name',
+                                value: 'Bar',
+                                sectionId: 'p-applicant-enter-your-name',
+                                theme: 'applicant-details'
+                            }
+                        ],
+                        sectionId: 'p-applicant-enter-your-name',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-have-you-been-known-by-any-other-names',
+                        type: 'simple',
+                        label: 'Have you been known by any other names?',
+                        value: true,
+                        valueLabel: 'Yes',
+                        sectionId: 'p-applicant-have-you-been-known-by-any-other-names',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-what-other-names-have-you-used',
+                        type: 'simple',
+                        label: 'What other names have you been known by?',
+                        value: 'Mr Test Testcase',
+                        sectionId: 'p-applicant-have-you-been-known-by-any-other-names',
+                        theme: 'applicant-details'
+                    },
+                    {
+                        id: 'q-applicant-british-citizen-or-eu-national',
+                        type: 'simple',
+                        label: 'Mr Foo Bar, are you a British citizen or EU national?',
+                        value: true,
+                        valueLabel: 'Yes',
+                        sectionId: 'p-applicant-british-citizen-or-eu-national',
+                        theme: 'applicant-details'
+                    }
+                ]
+            },
+            {
+                type: 'theme',
+                id: 'contact-details',
+                title: 'Contact details',
+                values: [
+                    {
+                        id: 'q-applicant-enter-your-email-address',
+                        type: 'simple',
+                        label: 'Enter your email address',
+                        value: 'bar@9f7b855e-586b-49f0-ac7a-026919732b06.gov.uk',
+                        sectionId: 'p-applicant-enter-your-email-address',
+                        theme: 'contact-details',
+                        format: {
+                            value: 'email'
+                        }
+                    }
+                ]
+            },
+            {
+                type: 'theme',
+                id: 'default',
+                title: 'Answers',
+                values: [
+                    {
+                        id: 'q-applicant-theme-undefined',
+                        type: 'simple',
+                        label: 'Enter your fav colour',
+                        value: 'red',
+                        sectionId: 'p-applicant-theme-undefined'
+                    },
+                    {
+                        id: 'q-applicant-theme-not-found',
+                        type: 'simple',
+                        label: 'Enter your fav colour',
+                        value: 'blue',
+                        sectionId: 'p-applicant-theme-not-found',
+                        theme: 'this-theme-is-not-found'
+                    }
+                ]
+            }
+        ]);
+    });
+});

--- a/questionnaire/utils/isQuestionnaireVersionCompatible/index.js
+++ b/questionnaire/utils/isQuestionnaireVersionCompatible/index.js
@@ -3,7 +3,7 @@
 const versionDiff = require('semver/functions/diff');
 const getInstalledModuleVersion = require('../getInstalledModuleVersion');
 
-const allowedVersionDifference = [null, 'patch']; // versionDiff returns null if versions are equal
+const allowedVersionDifference = [null, 'patch', 'minor']; // versionDiff returns null if versions are equal
 
 function isQuestionnaireVersionValid(questionnaireVersion) {
     const installedQuestionnaireVersion = getInstalledModuleVersion('q-templates-application');

--- a/questionnaire/utils/isQuestionnaireVersionCompatible/index.test.js
+++ b/questionnaire/utils/isQuestionnaireVersionCompatible/index.test.js
@@ -22,9 +22,9 @@ describe('VersionComparison', () => {
     });
 
     describe("There's a minor semver difference", () => {
-        it('Should return false', () => {
+        it('Should return true', () => {
             const actual = isVersionValid(minorVersionBump);
-            expect(actual).toBe(false);
+            expect(actual).toBe(true);
         });
     });
 


### PR DESCRIPTION
- Install the new templates which include UI schema information
- Sort the CYA page summary structure before returning it, rather than sorting it in q-transformer. This prevents differences in ordering between the PDF and CYA page