### PR TITLE
snyk setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,9 +13,34 @@ executors:
       # Image tool container
       - image: ministryofjustice/cloud-platform-tools
 jobs:
+  snyk_app_scan:
+    docker:
+      - image: node:24.15.0-trixie-slim
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-npm-{{checksum "package-lock.json" }}
+      - run:
+          name: Install CA certificates
+          command: |
+            apt-get update
+            apt-get install -y ca-certificates
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Install Snyk
+          command: npm install -g snyk@1.1304.0
+      - run:
+          name: Snyk test
+          command: snyk test --severity-threshold=high
+      - run:
+          name: Snyk monitor
+          command: snyk monitor
   build-for-test:
     docker:
-      - image: node:24.13.0-trixie-slim
+      - image: node:24.15.0-trixie-slim
     resource_class: large
     steps:
       - checkout
@@ -37,7 +62,7 @@ jobs:
             - ./node_modules
   test:
     docker:
-      - image: node:24.13.0-trixie-slim
+      - image: node:24.15.0-trixie-slim
     steps:
       - attach_workspace:
           at: ./
@@ -48,7 +73,7 @@ jobs:
           command: npx --no-install jest --ci --runInBand --bail --silent --coverage --projects jest.config.js
   lint:
     docker:
-      - image: node:24.13.0-trixie-slim
+      - image: node:24.15.0-trixie-slim
     steps:
       - attach_workspace:
           at: ./
@@ -66,6 +91,22 @@ jobs:
           name: Build docker image
           command: |
             docker build --target production --no-cache -t cica/cica-repo-dev .
+
+      - run:
+          name: Install Snyk CLI
+          command: |
+            apk add --update-cache curl
+            mkdir -p /usr/local/bin
+            curl -sL https://github.com/snyk/cli/releases/download/v1.1304.0/snyk-alpine -o /usr/local/bin/snyk
+            chmod +x /usr/local/bin/snyk
+            /usr/local/bin/snyk --version
+
+      - run:
+          name: Snyk container scan
+          command: |
+            /usr/local/bin/snyk container test cica/cica-repo-dev --file=Dockerfile --severity-threshold=high 
+            /usr/local/bin/snyk container monitor cica/cica-repo-dev
+
       - run:
           name: Archive Docker Image
           command: |
@@ -218,10 +259,14 @@ workflows:
       - lint:
           requires:
             - build-for-test
+      - snyk_app_scan:
+          requires:
+            - build-for-test
       - build:
           requires:
             - test
             - lint
+            - snyk_app_scan
       - publish_latest:
           requires:
             - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - checkout
       - restore_cache:
-          key: v1-npm-{{checksum "package-lock.json" }}
+          key: v1-npm-{{ checksum "package.json" }}-{{checksum "package-lock.json" }}
       - run:
           name: Install CA certificates
           command: |
@@ -35,9 +35,48 @@ jobs:
       - run:
           name: Snyk test
           command: snyk test --severity-threshold=high
+  snyk_monitor:
+    docker:
+      - image: node:24.15.0-trixie-slim
+    resource_class: large
+    steps:
+      - checkout
+      - restore_cache:
+          key: v1-npm-{{ checksum "package.json" }}-{{checksum "package-lock.json" }}
+      - run:
+          name: Install Dependencies
+          command: npm ci
+      - run:
+          name: Install Snyk
+          command: npm install -g snyk@1.1304.0
+      - run:
+          name: Install CA certificates
+          command: |
+            apt-get update
+            apt-get install -y ca-certificates
       - run:
           name: Snyk monitor
           command: snyk monitor
+  snyk_container_monitor:
+    executor: docker-publisher
+    steps:
+      - attach_workspace:
+          at: /tmp/workspace
+      - setup_remote_docker
+      - run:
+          name: Load archived Docker image
+          command: docker load -i /tmp/workspace/image.tar
+      - run:
+          name: Install Snyk CLI
+          command: |
+            apk add --update-cache curl
+            mkdir -p /usr/local/bin
+            curl -sL https://github.com/snyk/cli/releases/download/v1.1304.0/snyk-alpine -o /usr/local/bin/snyk
+            chmod +x /usr/local/bin/snyk
+      - run:
+          name: Snyk container monitor
+          command: |
+            /usr/local/bin/snyk container monitor cica/cica-repo-dev
   build-for-test:
     docker:
       - image: node:24.15.0-trixie-slim
@@ -104,8 +143,7 @@ jobs:
       - run:
           name: Snyk container scan
           command: |
-            /usr/local/bin/snyk container test cica/cica-repo-dev --file=Dockerfile --severity-threshold=high 
-            /usr/local/bin/snyk container monitor cica/cica-repo-dev
+            /usr/local/bin/snyk container test cica/cica-repo-dev --file=Dockerfile --severity-threshold=high
 
       - run:
           name: Archive Docker Image
@@ -262,6 +300,20 @@ workflows:
       - snyk_app_scan:
           requires:
             - build-for-test
+      - snyk_monitor:
+          requires:
+            - build-for-test
+          filters:
+            branches:
+              only:
+                - dcs-deploy
+      - snyk_container_monitor:
+          requires:
+            - push_image
+          filters:
+            branches:
+              only:
+                - dcs-deploy
       - build:
           requires:
             - test

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 # lets start from an image that already has nodejs installed
-FROM node:24.13.0-trixie-slim AS base
+FROM node:24.15.0-trixie-slim AS base
+
+USER root
+RUN npm install -g npm@11.13.0
 
 RUN groupadd -g 1014 dc_user \
     && useradd -rm -d /usr/src/app -u 1015 -g dc_user dc_user
@@ -46,7 +49,7 @@ CMD [ "npm", "start" ]
 # Change this when changing the production image
 # keep both in sync, production -slim variant
 # dev the non-slim variant
-FROM node:24.13.0-trixie AS dev
+FROM node:24.15.0-trixie AS dev
 
 RUN groupadd -g 1014 dc_user \
     && useradd -rm -d /usr/src/app -u 1015 -g dc_user dc_user

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 [![GitHub repo size](https://img.shields.io/github/repo-size/CriminalInjuriesCompensationAuthority/data-capture-service)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service)
 [![GitHub repo version](https://img.shields.io/github/package-json/v/CriminalInjuriesCompensationAuthority/data-capture-service)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/releases/latest)
-[![GitHub repo npm version](https://img.shields.io/badge/npm_version->=10.8.2-blue)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/package.json#L5)
-[![GitHub repo node version](https://img.shields.io/badge/node_version->=24.13.0-blue)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/package.json#L6)
+[![GitHub repo npm version](https://img.shields.io/badge/npm_version->=11.12.1-blue)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/package.json#L5)
+[![GitHub repo node version](https://img.shields.io/badge/node_version->=24.15.0-blue)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/package.json#L6)
 [![GitHub repo contributors](https://img.shields.io/github/contributors/CriminalInjuriesCompensationAuthority/data-capture-service)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/graphs/contributors)
 [![GitHub repo license](https://img.shields.io/github/package-json/license/CriminalInjuriesCompensationAuthority/data-capture-service)](https://github.com/CriminalInjuriesCompensationAuthority/data-capture-service/blob/master/LICENSE)
 
@@ -15,8 +15,8 @@ Data Capture Service is an API that returns data about an application for compen
 
 -   Windows machine running docker desktop.
 -   You have Node Version Manager (NVM) installed globally. <sup>(_recommended, not required_)</sup>
--   You have NPM `">=10.8.2"` installed globally.
--   You have Node `">=24.13.0"` installed globally.
+-   You have NPM `">=11.12.1"` installed globally.
+-   You have Node `">=24.15.0"` installed globally.
 -   You have the Postgres `create-tables.sql` file in a sibling directory named `postgres-scripts` (this mapping is defined in the `docker-compose.yml` file)
 
 ## Installing Data Capture Service

--- a/package-lock.json
+++ b/package-lock.json
@@ -60,8 +60,8 @@
                 "yamljs": "^0.3.0"
             },
             "engines": {
-                "node": ">=24.13.0",
-                "npm": ">=10.8.2"
+                "node": ">=24.15.0",
+                "npm": ">=11.12.1"
             }
         },
         "node_modules/@apidevtools/json-schema-ref-parser": {
@@ -403,23 +403,24 @@
             }
         },
         "node_modules/@aws-sdk/core": {
-            "version": "3.973.15",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.973.15.tgz",
-            "integrity": "sha512-AlC0oQ1/mdJ8vCIqu524j5RB7M8i8E24bbkZmya1CuiQxkY7SdIZAyw7NDNMGaNINQFq/8oGRMX0HeOfCVsl/A==",
+            "version": "3.974.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.5.tgz",
+            "integrity": "sha512-lMPlYlYfQdNZhlkJgnkmESwrY+hNh3PljmZ+37oAqLNdJ6rnILAwFSyc6B3bJeDOtMORNnMQIej0aTRuOlDyhQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@aws-sdk/xml-builder": "^3.972.8",
-                "@smithy/core": "^3.23.6",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/signature-v4": "^5.3.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-base64": "^4.3.1",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-utf8": "^4.2.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/xml-builder": "^3.972.19",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.4",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -427,12 +428,12 @@
             }
         },
         "node_modules/@aws-sdk/crc64-nvme": {
-            "version": "3.972.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.3.tgz",
-            "integrity": "sha512-UExeK+EFiq5LAcbHm96CQLSia+5pvpUVSAsVApscBzayb7/6dJBJKwV4/onsk4VbWSmqxDMcfuTD+pC4RxgZHg==",
+            "version": "3.972.7",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.7.tgz",
+            "integrity": "sha512-QUagVVBbC8gODCF6e1aV0mE2TXWB9Opz4k8EJFdNrujUVQm5R4AjJa1mpOqzwOuROBzqJU9zawzig7M96L8Ejg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -440,15 +441,15 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-env": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.13.tgz",
-            "integrity": "sha512-6ljXKIQ22WFKyIs1jbORIkGanySBHaPPTOI4OxACP5WXgbcR0nDYfqNJfXEGwCK7IzHdNbCSFsNKKs0qCexR8Q==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.31.tgz",
+            "integrity": "sha512-X/yGB73LmDW/6MdDJGCDzZBUXnM3ys4vs9l+5ZTJmiEswDdP1OjeoAFlFjVGS9o4KB2wZWQ9KOfdVNSSK6Ep3w==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -456,20 +457,20 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-http": {
-            "version": "3.972.15",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.15.tgz",
-            "integrity": "sha512-dJuSTreu/T8f24SHDNTjd7eQ4rabr0TzPh2UTCwYexQtzG3nTDKm1e5eIdhiroTMDkPEJeY+WPkA6F9wod/20A==",
+            "version": "3.972.33",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.33.tgz",
+            "integrity": "sha512-c0ZF+lwoWVvX5iCaGKL5T/4DnIw88CGqxA0BcBs3U86mIp5EZYPVg+KSPkMXOyokmADvNewiMUfSG2uFwjRp0g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/fetch-http-handler": "^5.3.11",
-                "@smithy/node-http-handler": "^4.4.12",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-stream": "^4.5.15",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -477,24 +478,24 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-ini": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.13.tgz",
-            "integrity": "sha512-JKSoGb7XeabZLBJptpqoZIFbROUIS65NuQnEHGOpuT9GuuZwag2qciKANiDLFiYk4u8nSrJC9JIOnWKVvPVjeA==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.35.tgz",
+            "integrity": "sha512-jsU4u/cRkKFLKQS0k918FQ27fzXLG5ENiLWQMYE6581zLeI2hWh04ptlrvZMB3wJT/5d+vSzJk74X1CMFr4y8Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/credential-provider-env": "^3.972.13",
-                "@aws-sdk/credential-provider-http": "^3.972.15",
-                "@aws-sdk/credential-provider-login": "^3.972.13",
-                "@aws-sdk/credential-provider-process": "^3.972.13",
-                "@aws-sdk/credential-provider-sso": "^3.972.13",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.13",
-                "@aws-sdk/nested-clients": "^3.996.3",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/credential-provider-imds": "^4.2.10",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/credential-provider-env": "^3.972.31",
+                "@aws-sdk/credential-provider-http": "^3.972.33",
+                "@aws-sdk/credential-provider-login": "^3.972.35",
+                "@aws-sdk/credential-provider-process": "^3.972.31",
+                "@aws-sdk/credential-provider-sso": "^3.972.35",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+                "@aws-sdk/nested-clients": "^3.997.3",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -502,18 +503,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-login": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.13.tgz",
-            "integrity": "sha512-RtYcrxdnJHKY8MFQGLltCURcjuMjnaQpAxPE6+/QEdDHHItMKZgabRe/KScX737F9vJMQsmJy9EmMOkCnoC1JQ==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.35.tgz",
+            "integrity": "sha512-5oa3j0cA50jPqgNhZ9XdJVopuzUf1klRb28/2MfLYWWiPi9DRVvbrBWT+DidbHTT36520VuXZJahQwR+YgSjrg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/nested-clients": "^3.996.3",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/nested-clients": "^3.997.3",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -521,22 +522,22 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-node": {
-            "version": "3.972.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.14.tgz",
-            "integrity": "sha512-WqoC2aliIjQM/L3oFf6j+op/enT2i9Cc4UTxxMEKrJNECkq4/PlKE5BOjSYFcq6G9mz65EFbXJh7zOU4CvjSKQ==",
+            "version": "3.972.36",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.36.tgz",
+            "integrity": "sha512-4nT2T8Z7vH8KE9EdjEsuIlHpZSlcaK2PrKbQBjuUGU46BCCzF3WvP0u0Uiosni3Ykmmn4rWLVawoOCLotUtCbg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/credential-provider-env": "^3.972.13",
-                "@aws-sdk/credential-provider-http": "^3.972.15",
-                "@aws-sdk/credential-provider-ini": "^3.972.13",
-                "@aws-sdk/credential-provider-process": "^3.972.13",
-                "@aws-sdk/credential-provider-sso": "^3.972.13",
-                "@aws-sdk/credential-provider-web-identity": "^3.972.13",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/credential-provider-imds": "^4.2.10",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/credential-provider-env": "^3.972.31",
+                "@aws-sdk/credential-provider-http": "^3.972.33",
+                "@aws-sdk/credential-provider-ini": "^3.972.35",
+                "@aws-sdk/credential-provider-process": "^3.972.31",
+                "@aws-sdk/credential-provider-sso": "^3.972.35",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.35",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -544,16 +545,16 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-process": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.13.tgz",
-            "integrity": "sha512-rsRG0LQA4VR+jnDyuqtXi2CePYSmfm5GNL9KxiW8DSe25YwJSr06W8TdUfONAC+rjsTI+aIH2rBGG5FjMeANrw==",
+            "version": "3.972.31",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.31.tgz",
+            "integrity": "sha512-eKeT4MXumpBJsrDLCYcSzIkFPVTFn/es7It2oogp2OhU/ic7P/+xzFpQx9ZhwtXS57Mc5S42BPWi7lHmvs/nYg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -561,18 +562,18 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-sso": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.13.tgz",
-            "integrity": "sha512-fr0UU1wx8kNHDhTQBXioc/YviSW8iXuAxHvnH7eQUtn8F8o/FU3uu6EUMvAQgyvn7Ne5QFnC0Cj0BFlwCk+RFw==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.35.tgz",
+            "integrity": "sha512-bCuBdfnj0KGDMdLp6utMTLiJcFN2ek9EgZinxQZZSc3FxjJ/HSqeqab2cjbnoNfy8RM6suDCsRkmVY1izp9I+A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/nested-clients": "^3.996.3",
-                "@aws-sdk/token-providers": "3.999.0",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/nested-clients": "^3.997.3",
+                "@aws-sdk/token-providers": "3.1036.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -580,17 +581,17 @@
             }
         },
         "node_modules/@aws-sdk/credential-provider-web-identity": {
-            "version": "3.972.13",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.13.tgz",
-            "integrity": "sha512-a6iFMh1pgUH0TdcouBppLJUfPM7Yd3R9S1xFodPtCRoLqCz2RQFA3qjA8x4112PVYXEd4/pHX2eihapq39w0rA==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.35.tgz",
+            "integrity": "sha512-swW6Bwvl8lanyEMtZOWE/oR6yqcRQH4HTQZUVsnDVgoXvRjRywpYpLv2BWwjUFyjPrqsdX6FeTkf4tMSe/qFTQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/nested-clients": "^3.996.3",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/nested-clients": "^3.997.3",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -631,24 +632,24 @@
             }
         },
         "node_modules/@aws-sdk/middleware-flexible-checksums": {
-            "version": "3.973.1",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.973.1.tgz",
-            "integrity": "sha512-QLXsxsI6VW8LuGK+/yx699wzqP/NMCGk/hSGP+qtB+Lcff+23UlbahyouLlk+nfT7Iu021SkXBhnAuVd6IZcPw==",
+            "version": "3.974.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.13.tgz",
+            "integrity": "sha512-b6QUe2hQX9XsnCzp6mtzVaERhganDKeb8lmGL6pVhr7rRVH9S9keDFW7uKytuuqmcY5943FixoGqn/QL+sbUBA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/crc32": "5.2.0",
                 "@aws-crypto/crc32c": "5.2.0",
                 "@aws-crypto/util": "5.2.0",
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/crc64-nvme": "^3.972.3",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/is-array-buffer": "^4.2.1",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-stream": "^4.5.15",
-                "@smithy/util-utf8": "^4.2.1",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/crc64-nvme": "^3.972.7",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -656,14 +657,14 @@
             }
         },
         "node_modules/@aws-sdk/middleware-host-header": {
-            "version": "3.972.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.6.tgz",
-            "integrity": "sha512-5XHwjPH1lHB+1q4bfC7T8Z5zZrZXfaLcjSMwTd1HPSPrCmPFMbg3UQ5vgNWcVj0xoX4HWqTGkSf2byrjlnRg5w==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.10.tgz",
+            "integrity": "sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -685,13 +686,13 @@
             }
         },
         "node_modules/@aws-sdk/middleware-logger": {
-            "version": "3.972.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.6.tgz",
-            "integrity": "sha512-iFnaMFMQdljAPrvsCVKYltPt2j40LQqukAbXvW7v0aL5I+1GO7bZ/W8m12WxW3gwyK5p5u1WlHg8TSAizC5cZw==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.10.tgz",
+            "integrity": "sha512-OOuGvvz1Dm20SjZo5oEBePFqxt5nf8AwkNDSyUHvD9/bfNASmstcYxFAHUowy4n6Io7mWUZ04JURZwSBvyQanQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -699,15 +700,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-recursion-detection": {
-            "version": "3.972.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.6.tgz",
-            "integrity": "sha512-dY4v3of5EEMvik6+UDwQ96KfUFDk8m1oZDdkSc5lwi4o7rFrjnv0A+yTV+gu230iybQZnKgDLg/rt2P3H+Vscw==",
+            "version": "3.972.11",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.11.tgz",
+            "integrity": "sha512-+zz6f79Kj9V5qFK2P+D8Ehjnw4AhphAlCAsPjUqEcInA9umtSSKMrHbSagEeOIsDNuvVrH98bjRHcyQukTrhaQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
+                "@aws-sdk/types": "^3.973.8",
                 "@aws/lambda-invoke-store": "^0.2.2",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -715,24 +716,24 @@
             }
         },
         "node_modules/@aws-sdk/middleware-sdk-s3": {
-            "version": "3.972.15",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.15.tgz",
-            "integrity": "sha512-WDLgssevOU5BFx1s8jA7jj6cE5HuImz28sy9jKOaVtz0AW1lYqSzotzdyiybFaBcQTs5zxXOb2pUfyMxgEKY3Q==",
+            "version": "3.972.34",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.34.tgz",
+            "integrity": "sha512-/UL96JKjsjdodcRRMKl99tLQvK6Oi9ptLC9iU1yiTF/ruaDX0mtBBtnLNZDxIZRJOCVOtB49ed1YaTadqygk8Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@aws-sdk/util-arn-parser": "^3.972.2",
-                "@smithy/core": "^3.23.6",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/signature-v4": "^5.3.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-config-provider": "^4.2.1",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-stream": "^4.5.15",
-                "@smithy/util-utf8": "^4.2.1",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-arn-parser": "^3.972.3",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -771,17 +772,18 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent": {
-            "version": "3.972.15",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.15.tgz",
-            "integrity": "sha512-ABlFVcIMmuRAwBT+8q5abAxOr7WmaINirDJBnqGY5b5jSDo00UMlg/G4a0xoAgwm6oAECeJcwkvDlxDwKf58fQ==",
+            "version": "3.972.35",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.35.tgz",
+            "integrity": "sha512-hOFWNOjVmOocpRlrU04nYxjMOeoe0Obu5AXEuhB8zblMCPl3cG1hdluQCZERRKFyhMQjwZnDbhSHjoMUjetFGw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@aws-sdk/util-endpoints": "^3.996.3",
-                "@smithy/core": "^3.23.6",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-retry": "^4.3.4",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -789,15 +791,15 @@
             }
         },
         "node_modules/@aws-sdk/middleware-user-agent/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-            "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+            "version": "3.996.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+            "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/types": "^4.13.0",
-                "@smithy/url-parser": "^4.2.10",
-                "@smithy/util-endpoints": "^3.3.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-endpoints": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -805,48 +807,66 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients": {
-            "version": "3.996.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.996.3.tgz",
-            "integrity": "sha512-AU5TY1V29xqwg/MxmA2odwysTez+ccFAhmfRJk+QZT5HNv90UTA9qKd1J9THlsQkvmH7HWTEV1lDNxkQO5PzNw==",
+            "version": "3.997.3",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.3.tgz",
+            "integrity": "sha512-SivE6GP228IVgfsrr2c/vqTg95X0Qj39Yw4uIrcddpkUzIltNMoNOR62leHOLhODfjv9K8X2mPTwS69A5kT0nQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@aws-crypto/sha256-browser": "5.2.0",
                 "@aws-crypto/sha256-js": "5.2.0",
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/middleware-host-header": "^3.972.6",
-                "@aws-sdk/middleware-logger": "^3.972.6",
-                "@aws-sdk/middleware-recursion-detection": "^3.972.6",
-                "@aws-sdk/middleware-user-agent": "^3.972.15",
-                "@aws-sdk/region-config-resolver": "^3.972.6",
-                "@aws-sdk/types": "^3.973.4",
-                "@aws-sdk/util-endpoints": "^3.996.3",
-                "@aws-sdk/util-user-agent-browser": "^3.972.6",
-                "@aws-sdk/util-user-agent-node": "^3.973.0",
-                "@smithy/config-resolver": "^4.4.9",
-                "@smithy/core": "^3.23.6",
-                "@smithy/fetch-http-handler": "^5.3.11",
-                "@smithy/hash-node": "^4.2.10",
-                "@smithy/invalid-dependency": "^4.2.10",
-                "@smithy/middleware-content-length": "^4.2.10",
-                "@smithy/middleware-endpoint": "^4.4.20",
-                "@smithy/middleware-retry": "^4.4.37",
-                "@smithy/middleware-serde": "^4.2.11",
-                "@smithy/middleware-stack": "^4.2.10",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/node-http-handler": "^4.4.12",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
-                "@smithy/url-parser": "^4.2.10",
-                "@smithy/util-base64": "^4.3.1",
-                "@smithy/util-body-length-browser": "^4.2.1",
-                "@smithy/util-body-length-node": "^4.2.2",
-                "@smithy/util-defaults-mode-browser": "^4.3.36",
-                "@smithy/util-defaults-mode-node": "^4.2.39",
-                "@smithy/util-endpoints": "^3.3.1",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-retry": "^4.2.10",
-                "@smithy/util-utf8": "^4.2.1",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/middleware-host-header": "^3.972.10",
+                "@aws-sdk/middleware-logger": "^3.972.10",
+                "@aws-sdk/middleware-recursion-detection": "^3.972.11",
+                "@aws-sdk/middleware-user-agent": "^3.972.35",
+                "@aws-sdk/region-config-resolver": "^3.972.13",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.22",
+                "@aws-sdk/types": "^3.973.8",
+                "@aws-sdk/util-endpoints": "^3.996.8",
+                "@aws-sdk/util-user-agent-browser": "^3.972.10",
+                "@aws-sdk/util-user-agent-node": "^3.973.21",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/core": "^3.23.17",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/hash-node": "^4.2.14",
+                "@smithy/invalid-dependency": "^4.2.14",
+                "@smithy/middleware-content-length": "^4.2.14",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-retry": "^4.5.5",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-body-length-node": "^4.2.3",
+                "@smithy/util-defaults-mode-browser": "^4.3.49",
+                "@smithy/util-defaults-mode-node": "^4.2.54",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.4",
+                "@smithy/util-utf8": "^4.2.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.22",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.22.tgz",
+            "integrity": "sha512-/rXhMXteD+BqhFd0nYprAgcZ/KtU+963uftPqd3tiFcFfooHZINXUGtOmo2SQjRVauCTNqIEzkwuSETdZFqTTA==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/middleware-sdk-s3": "^3.972.34",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/signature-v4": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -854,15 +874,15 @@
             }
         },
         "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/util-endpoints": {
-            "version": "3.996.3",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.3.tgz",
-            "integrity": "sha512-yWIQSNiCjykLL+ezN5A+DfBb1gfXTytBxm57e64lYmwxDHNmInYHRJYYRAGWG1o77vKEiWaw4ui28e3yb1k5aQ==",
+            "version": "3.996.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.996.8.tgz",
+            "integrity": "sha512-oOZHcRDihk5iEe5V25NVWg45b3qEA8OpHWVdU/XQh8Zj4heVPAJqWvMphQnU7LkufmUo10EpvFPZuQMiFLJK3g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/types": "^4.13.0",
-                "@smithy/url-parser": "^4.2.10",
-                "@smithy/util-endpoints": "^3.3.1",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-endpoints": "^3.4.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -870,15 +890,15 @@
             }
         },
         "node_modules/@aws-sdk/region-config-resolver": {
-            "version": "3.972.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.6.tgz",
-            "integrity": "sha512-Aa5PusHLXAqLTX1UKDvI3pHQJtIsF7Q+3turCHqfz/1F61/zDMWfbTC8evjhrrYVAtz9Vsv3SJ/waSUeu7B6gw==",
+            "version": "3.972.13",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.13.tgz",
+            "integrity": "sha512-CvJ2ZIjK/jVD/lbOpowBVElJyC1YxLTIJ13yM0AEo0t2v7swOzGjSA6lJGH+DwZXQhcjUjoYwc8bVYCX5MDr1A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/config-resolver": "^4.4.9",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -903,17 +923,17 @@
             }
         },
         "node_modules/@aws-sdk/token-providers": {
-            "version": "3.999.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.999.0.tgz",
-            "integrity": "sha512-cx0hHUlgXULfykx4rdu/ciNAJaa3AL5xz3rieCz7NKJ68MJwlj3664Y8WR5MGgxfyYJBdamnkjNSx5Kekuc0cg==",
+            "version": "3.1036.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1036.0.tgz",
+            "integrity": "sha512-aNSJ6jjDYayxN9ZA1JpycVScX93Lx03kKZ1EXt3DGOTahcWVLJj3oLAlop0xKP+vP2Ga2t49p1tEaMkTbCCaZA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/core": "^3.973.15",
-                "@aws-sdk/nested-clients": "^3.996.3",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/core": "^3.974.5",
+                "@aws-sdk/nested-clients": "^3.997.3",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -921,12 +941,12 @@
             }
         },
         "node_modules/@aws-sdk/types": {
-            "version": "3.973.4",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.4.tgz",
-            "integrity": "sha512-RW60aH26Bsc016Y9B98hC0Plx6fK5P2v/iQYwMzrSjiDh1qRMUCP6KrXHYEHe3uFvKiOC93Z9zk4BJsUi6Tj1Q==",
+            "version": "3.973.8",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.8.tgz",
+            "integrity": "sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -934,9 +954,9 @@
             }
         },
         "node_modules/@aws-sdk/util-arn-parser": {
-            "version": "3.972.2",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.2.tgz",
-            "integrity": "sha512-VkykWbqMjlSgBFDyrY3nOSqupMc6ivXuGmvci6Q3NnLq5kC+mKQe2QBZ4nrWRE/jqOxeFP2uYzLtwncYYcvQDg==",
+            "version": "3.972.3",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.972.3.tgz",
+            "integrity": "sha512-HzSD8PMFrvgi2Kserxuff5VitNq2sgf3w9qxmskKDiDTThWfVteJxuCS9JXiPIPtmCrp+7N9asfIaVhBFORllA==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -974,27 +994,28 @@
             }
         },
         "node_modules/@aws-sdk/util-user-agent-browser": {
-            "version": "3.972.6",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.6.tgz",
-            "integrity": "sha512-Fwr/llD6GOrFgQnKaI2glhohdGuBDfHfora6iG9qsBBBR8xv1SdCSwbtf5CWlUdCw5X7g76G/9Hf0Inh0EmoxA==",
+            "version": "3.972.10",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.10.tgz",
+            "integrity": "sha512-FAzqXvfEssGdSIz8ejatan0bOdx1qefBWKF/gWmVBXIP1HkS7v/wjjaqrAGGKvyihrXTXW00/2/1nTJtxpXz7g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/types": "^4.14.1",
                 "bowser": "^2.11.0",
                 "tslib": "^2.6.2"
             }
         },
         "node_modules/@aws-sdk/util-user-agent-node": {
-            "version": "3.973.0",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.0.tgz",
-            "integrity": "sha512-A9J2G4Nf236e9GpaC1JnA8wRn6u6GjnOXiTwBLA6NUJhlBTIGfrTy+K1IazmF8y+4OFdW3O5TZlhyspJMqiqjA==",
+            "version": "3.973.21",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.21.tgz",
+            "integrity": "sha512-Av4UHTcAWgdvbN0IP9pbtf4Qa1+6LtJqQdZWj5pLn5J67w0pnJJAZZ+7JPPcj2KN3378zD2JDM9DwJKEyvyMTQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@aws-sdk/middleware-user-agent": "^3.972.15",
-                "@aws-sdk/types": "^3.973.4",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/types": "^4.13.0",
+                "@aws-sdk/middleware-user-agent": "^3.972.35",
+                "@aws-sdk/types": "^3.973.8",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1010,13 +1031,13 @@
             }
         },
         "node_modules/@aws-sdk/xml-builder": {
-            "version": "3.972.14",
-            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.14.tgz",
-            "integrity": "sha512-G/Yd8Bnnyh8QrqLf8jWJbixEnScUFW24e/wOBGYdw1Cl4r80KX/DvHyM2GVZ2vTp7J4gTEr8IXJlTadA8+UfuQ==",
+            "version": "3.972.19",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.19.tgz",
+            "integrity": "sha512-Cw8IOMdBUEIl8ZlhRC3Dc/E64D5B5/8JhV6vhPLiPfJwcRC84S6F8aBOIi/N4vR9ZyA4I5Cc0Ateb/9EHaJXeQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.1",
-                "fast-xml-parser": "5.5.6",
+                "@smithy/types": "^4.14.1",
+                "fast-xml-parser": "5.7.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -1063,7 +1084,6 @@
             "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@babel/code-frame": "^7.29.0",
                 "@babel/generator": "^7.29.0",
@@ -2305,6 +2325,18 @@
                 "url": "https://paulmillr.com/funding/"
             }
         },
+        "node_modules/@nodable/entities": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+            "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/nodable"
+                }
+            ],
+            "license": "MIT"
+        },
         "node_modules/@nodelib/fs.scandir": {
             "version": "2.1.5",
             "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -2349,7 +2381,6 @@
             "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
             "dev": true,
             "license": "Apache-2.0",
-            "peer": true,
             "engines": {
                 "node": ">=8.0.0"
             }
@@ -2917,16 +2948,16 @@
             }
         },
         "node_modules/@smithy/config-resolver": {
-            "version": "4.4.9",
-            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.9.tgz",
-            "integrity": "sha512-ejQvXqlcU30h7liR9fXtj7PIAau1t/sFbJpgWPfiYDs7zd16jpH0IsSXKcba2jF6ChTXvIjACs27kNMc5xxE2Q==",
+            "version": "4.4.17",
+            "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.4.17.tgz",
+            "integrity": "sha512-TzDZcAnhTyAHbXVxWZo7/tEcrIeFq20IBk8So3OLOetWpR8EwY/yEqBMBFaJMeyEiREDq4NfEl+qO3OAUD+vbQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-config-provider": "^4.2.1",
-                "@smithy/util-endpoints": "^3.3.1",
-                "@smithy/util-middleware": "^4.2.10",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-config-provider": "^4.2.2",
+                "@smithy/util-endpoints": "^3.4.2",
+                "@smithy/util-middleware": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2934,20 +2965,20 @@
             }
         },
         "node_modules/@smithy/core": {
-            "version": "3.23.6",
-            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.6.tgz",
-            "integrity": "sha512-4xE+0L2NrsFKpEVFlFELkIHQddBvMbQ41LRIP74dGCXnY1zQ9DgksrBcRBDJT+iOzGy4VEJIeU3hkUK5mn06kg==",
+            "version": "3.23.17",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.23.17.tgz",
+            "integrity": "sha512-x7BlLbUFL8NWCGjMF9C+1N5cVCxcPa7g6Tv9B4A2luWx3be3oU8hQ96wIwxe/s7OhIzvoJH73HAUSg5JXVlEtQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/middleware-serde": "^4.2.11",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-base64": "^4.3.1",
-                "@smithy/util-body-length-browser": "^4.2.1",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-stream": "^4.5.15",
-                "@smithy/util-utf8": "^4.2.1",
-                "@smithy/uuid": "^1.1.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-body-length-browser": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-stream": "^4.5.25",
+                "@smithy/util-utf8": "^4.2.2",
+                "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -2955,15 +2986,15 @@
             }
         },
         "node_modules/@smithy/credential-provider-imds": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.10.tgz",
-            "integrity": "sha512-3bsMLJJLTZGZqVGGeBVFfLzuRulVsGTj12BzRKODTHqUABpIr0jMN1vN3+u6r2OfyhAQ2pXaMZWX/swBK5I6PQ==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.2.14.tgz",
+            "integrity": "sha512-Au28zBN48ZAoXdooGUHemuVBrkE+Ie6RPmGNIAJsFqj33Vhb6xAgRifUydZ2aY+M+KaMAETAlKk5NC5h1G7wpg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/url-parser": "^4.2.10",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3041,15 +3072,15 @@
             }
         },
         "node_modules/@smithy/fetch-http-handler": {
-            "version": "5.3.11",
-            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.11.tgz",
-            "integrity": "sha512-wbTRjOxdFuyEg0CpumjZO0hkUl+fetJFqxNROepuLIoijQh51aMBmzFLfoQdwRjxsuuS2jizzIUTjPWgd8pd7g==",
+            "version": "5.3.17",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.3.17.tgz",
+            "integrity": "sha512-bXOvQzaSm6MnmLaWA1elgfQcAtN4UP3vXqV97bHuoOrHQOJiLT3ds6o9eo5bqd0TJfRFpzdGnDQdW3FACiAVdw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/querystring-builder": "^4.2.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-base64": "^4.3.1",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3072,14 +3103,14 @@
             }
         },
         "node_modules/@smithy/hash-node": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.10.tgz",
-            "integrity": "sha512-1VzIOI5CcsvMDvP3iv1vG/RfLJVVVc67dCRyLSB2Hn9SWCZrDO3zvcIzj3BfEtqRW5kcMg5KAeVf1K3dR6nD3w==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.2.14.tgz",
+            "integrity": "sha512-8ZBDY2DD4wr+GGjTpPtiglEsqr0lUP+KHqgZcWczFf6qeZ/YRjMIOoQWVQlmwu7EtxKTd8YXD8lblmYcpBIA1g==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-buffer-from": "^4.2.1",
-                "@smithy/util-utf8": "^4.2.1",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3101,12 +3132,12 @@
             }
         },
         "node_modules/@smithy/invalid-dependency": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.10.tgz",
-            "integrity": "sha512-vy9KPNSFUU0ajFYk0sDZIYiUlAWGEAhRfehIr5ZkdFrRFTAuXEPUd41USuqHU6vvLX4r6Q9X7MKBco5+Il0Org==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.2.14.tgz",
+            "integrity": "sha512-c21qJiTSb25xvvOp+H2TNZzPCngrvl5vIPqPB8zQ/DmJF4QWXO19x1dWfMJZ6wZuuWUPPm0gV8C0cU3+ifcWuw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3114,9 +3145,9 @@
             }
         },
         "node_modules/@smithy/is-array-buffer": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.1.tgz",
-            "integrity": "sha512-Yfu664Qbf1B4IYIsYgKoABt010daZjkaCRvdU/sPnZG6TtHOB0md0RjNdLGzxe5UIdn9js4ftPICzmkRa9RJ4Q==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-4.2.2.tgz",
+            "integrity": "sha512-n6rQ4N8Jj4YTQO3YFrlgZuwKodf4zUFs7EJIWH86pSCWBaAtAGBFfCM7Wx6D2bBJ2xqFNxGBSrUWswT3M0VJow==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3140,13 +3171,13 @@
             }
         },
         "node_modules/@smithy/middleware-content-length": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.10.tgz",
-            "integrity": "sha512-TQZ9kX5c6XbjhaEBpvhSvMEZ0klBs1CFtOdPFwATZSbC9UeQfKHPLPN9Y+I6wZGMOavlYTOlHEPDrt42PMSH9w==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.2.14.tgz",
+            "integrity": "sha512-xhHq7fX4/3lv5NHxLUk3OeEvl0xZ+Ek3qIbWaCL4f9JwgDZEclPBElljaZCAItdGPQl/kSM4LPMOpy1MYgprpw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3154,18 +3185,18 @@
             }
         },
         "node_modules/@smithy/middleware-endpoint": {
-            "version": "4.4.20",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.20.tgz",
-            "integrity": "sha512-9W6Np4ceBP3XCYAGLoMCmn8t2RRVzuD1ndWPLBbv7H9CrwM9Bprf6Up6BM9ZA/3alodg0b7Kf6ftBK9R1N04vw==",
+            "version": "4.4.32",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.4.32.tgz",
+            "integrity": "sha512-ZZkgyjnJppiZbIm6Qbx92pbXYi1uzenIvGhBSCDlc7NwuAkiqSgS75j1czAD25ZLs2FjMjYy1q7gyRVWG6JA0Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.23.6",
-                "@smithy/middleware-serde": "^4.2.11",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
-                "@smithy/url-parser": "^4.2.10",
-                "@smithy/util-middleware": "^4.2.10",
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-serde": "^4.2.20",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
+                "@smithy/url-parser": "^4.2.14",
+                "@smithy/util-middleware": "^4.2.14",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3173,19 +3204,20 @@
             }
         },
         "node_modules/@smithy/middleware-retry": {
-            "version": "4.4.37",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.4.37.tgz",
-            "integrity": "sha512-/1psZZllBBSQ7+qo5+hhLz7AEPGLx3Z0+e3ramMBEuPK2PfvLK4SrncDB9VegX5mBn+oP/UTDrM6IHrFjvX1ZA==",
+            "version": "4.5.5",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.5.5.tgz",
+            "integrity": "sha512-wnYOpB5vATFKWrY2Z9Alb0KhjZI6AbzU6Fbz3Hq2GnURdRYWB4q+qWivQtSTwXcmWUA3MZ6krfwL6Cq5MAbxsA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/service-error-classification": "^4.2.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-retry": "^4.2.10",
-                "@smithy/uuid": "^1.1.1",
+                "@smithy/core": "^3.23.17",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/service-error-classification": "^4.3.0",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-retry": "^4.3.4",
+                "@smithy/uuid": "^1.1.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3193,13 +3225,14 @@
             }
         },
         "node_modules/@smithy/middleware-serde": {
-            "version": "4.2.11",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.11.tgz",
-            "integrity": "sha512-STQdONGPwbbC7cusL60s7vOa6He6A9w2jWhoapL0mgVjmR19pr26slV+yoSP76SIssMTX/95e5nOZ6UQv6jolg==",
+            "version": "4.2.20",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.2.20.tgz",
+            "integrity": "sha512-Lx9JMO9vArPtiChE3wbEZ5akMIDQpWQtlu90lhACQmNOXcGXRbaDywMHDzuDZ2OkZzP+9wQfZi3YJT9F67zTQQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/core": "^3.23.17",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3207,12 +3240,12 @@
             }
         },
         "node_modules/@smithy/middleware-stack": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.10.tgz",
-            "integrity": "sha512-pmts/WovNcE/tlyHa8z/groPeOtqtEpp61q3W0nW1nDJuMq/x+hWa/OVQBtgU0tBqupeXq0VBOLA4UZwE8I0YA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.2.14.tgz",
+            "integrity": "sha512-2dvkUKLuFdKsCRmOE4Mn63co0Djtsm+JMh0bYZQupN1pJwMeE8FmQmRLLzzEMN0dnNi7CDCYYH8F0EVwWiPBeA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3220,14 +3253,14 @@
             }
         },
         "node_modules/@smithy/node-config-provider": {
-            "version": "4.3.10",
-            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.10.tgz",
-            "integrity": "sha512-UALRbJtVX34AdP2VECKVlnNgidLHA2A7YgcJzwSBg1hzmnO/bZBHl/LDQQyYifzUwp1UOODnl9JJ3KNawpUJ9w==",
+            "version": "4.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.3.14.tgz",
+            "integrity": "sha512-S+gFjyo/weSVL0P1b9Ts8C/CwIfNCgUPikk3sl6QVsfE/uUuO+QsF+NsE/JkpvWqqyz1wg7HFdiaZuj5CoBMRg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/shared-ini-file-loader": "^4.4.5",
-                "@smithy/types": "^4.13.0",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/shared-ini-file-loader": "^4.4.9",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3235,15 +3268,14 @@
             }
         },
         "node_modules/@smithy/node-http-handler": {
-            "version": "4.4.12",
-            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.4.12.tgz",
-            "integrity": "sha512-zo1+WKJkR9x7ZtMeMDAAsq2PufwiLDmkhcjpWPRRkmeIuOm6nq1qjFICSZbnjBvD09ei8KMo26BWxsu2BUU+5w==",
+            "version": "4.6.1",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.6.1.tgz",
+            "integrity": "sha512-iB+orM4x3xrr57X3YaXazfKnntl0LHlZB1kcXSGzMV1Tt0+YwEjGlbjk/44qEGtBzXAz6yFDzkYTKSV6Pj2HUg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/abort-controller": "^4.2.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/querystring-builder": "^4.2.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/querystring-builder": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3251,12 +3283,12 @@
             }
         },
         "node_modules/@smithy/property-provider": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.10.tgz",
-            "integrity": "sha512-5jm60P0CU7tom0eNrZ7YrkgBaoLFXzmqB0wVS+4uK8PPGmosSrLNf6rRd50UBvukztawZ7zyA8TxlrKpF5z9jw==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/property-provider/-/property-provider-4.2.14.tgz",
+            "integrity": "sha512-WuM31CgfsnQ/10i7NYr0PyxqknD72Y5uMfUMVSniPjbEPceiTErb4eIqJQ+pdxNEAUEWrewrGjIRjVbVHsxZiQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3264,12 +3296,12 @@
             }
         },
         "node_modules/@smithy/protocol-http": {
-            "version": "5.3.10",
-            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.10.tgz",
-            "integrity": "sha512-2NzVWpYY0tRdfeCJLsgrR89KE3NTWT2wGulhNUxYlRmtRmPwLQwKzhrfVaiNlA9ZpJvbW7cjTVChYKgnkqXj1A==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.3.14.tgz",
+            "integrity": "sha512-dN5F8kHx8RNU0r+pCwNmFZyz6ChjMkzShy/zup6MtkRmmix4vZzJdW+di7x//b1LiynIev88FM18ie+wwPcQtQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3277,13 +3309,13 @@
             }
         },
         "node_modules/@smithy/querystring-builder": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.10.tgz",
-            "integrity": "sha512-HeN7kEvuzO2DmAzLukE9UryiUvejD3tMp9a1D1NJETerIfKobBUCLfviP6QEk500166eD2IATaXM59qgUI+YDA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-builder/-/querystring-builder-4.2.14.tgz",
+            "integrity": "sha512-XYA5Z0IqTeF+5XDdh4BBmSA0HvbgVZIyv4cmOoUheDNR57K1HgBp9ukUMx3Cr3XpDHHpLBnexPE3LAtDsZkj2A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-uri-escape": "^4.2.1",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-uri-escape": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3291,12 +3323,12 @@
             }
         },
         "node_modules/@smithy/querystring-parser": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.10.tgz",
-            "integrity": "sha512-4Mh18J26+ao1oX5wXJfWlTT+Q1OpDR8ssiC9PDOuEgVBGloqg18Fw7h5Ct8DyT9NBYwJgtJ2nLjKKFU6RP1G1Q==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/querystring-parser/-/querystring-parser-4.2.14.tgz",
+            "integrity": "sha512-hr+YyqBD23GVvRxGGrcc/oOeNlK3PzT5Fu4dzrDXxzS1LpFiuL2PQQqKPs87M79aW7ziMs+nvB3qdw77SqE7Lw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3304,24 +3336,24 @@
             }
         },
         "node_modules/@smithy/service-error-classification": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.2.10.tgz",
-            "integrity": "sha512-0R/+/Il5y8nB/By90o8hy/bWVYptbIfvoTYad0igYQO5RefhNCDmNzqxaMx7K1t/QWo0d6UynqpqN5cCQt1MCg==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/@smithy/service-error-classification/-/service-error-classification-4.3.0.tgz",
+            "integrity": "sha512-9jKsBYQRPR0xBLgc2415RsA5PIcP2sis4oBdN9s0D13cg1B1284mNTjx9Yc+BEERXzuPm5ObktI96OxsKh8E9A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0"
+                "@smithy/types": "^4.14.1"
             },
             "engines": {
                 "node": ">=18.0.0"
             }
         },
         "node_modules/@smithy/shared-ini-file-loader": {
-            "version": "4.4.5",
-            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.5.tgz",
-            "integrity": "sha512-pHgASxl50rrtOztgQCPmOXFjRW+mCd7ALr/3uXNzRrRoGV5G2+78GOsQ3HlQuBVHCh9o6xqMNvlIKZjWn4Euug==",
+            "version": "4.4.9",
+            "resolved": "https://registry.npmjs.org/@smithy/shared-ini-file-loader/-/shared-ini-file-loader-4.4.9.tgz",
+            "integrity": "sha512-495/V2I15SHgedSJoDPD23JuSfKAp726ZI1V0wtjB07Wh7q/0tri/0e0DLefZCHgxZonrGKt/OCTpAtP1wE1kQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3329,18 +3361,18 @@
             }
         },
         "node_modules/@smithy/signature-v4": {
-            "version": "5.3.10",
-            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.10.tgz",
-            "integrity": "sha512-Wab3wW8468WqTKIxI+aZe3JYO52/RYT/8sDOdzkUhjnLakLe9qoQqIcfih/qxcF4qWEFoWBszY0mj5uxffaVXA==",
+            "version": "5.3.14",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.3.14.tgz",
+            "integrity": "sha512-1D9Y/nmlVjCeSivCbhZ7hgEpmHyY1h0GvpSZt3l0xcD9JjmjVC1CHOozS6+Gh+/ldMH8JuJ6cujObQqfayAVFA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.1",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-hex-encoding": "^4.2.1",
-                "@smithy/util-middleware": "^4.2.10",
-                "@smithy/util-uri-escape": "^4.2.1",
-                "@smithy/util-utf8": "^4.2.1",
+                "@smithy/is-array-buffer": "^4.2.2",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-middleware": "^4.2.14",
+                "@smithy/util-uri-escape": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3348,17 +3380,17 @@
             }
         },
         "node_modules/@smithy/smithy-client": {
-            "version": "4.12.0",
-            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.0.tgz",
-            "integrity": "sha512-R8bQ9K3lCcXyZmBnQqUZJF4ChZmtWT5NLi6x5kgWx5D+/j0KorXcA0YcFg/X5TOgnTCy1tbKc6z2g2y4amFupQ==",
+            "version": "4.12.13",
+            "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.12.13.tgz",
+            "integrity": "sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/core": "^3.23.6",
-                "@smithy/middleware-endpoint": "^4.4.20",
-                "@smithy/middleware-stack": "^4.2.10",
-                "@smithy/protocol-http": "^5.3.10",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-stream": "^4.5.15",
+                "@smithy/core": "^3.23.17",
+                "@smithy/middleware-endpoint": "^4.4.32",
+                "@smithy/middleware-stack": "^4.2.14",
+                "@smithy/protocol-http": "^5.3.14",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-stream": "^4.5.25",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3366,9 +3398,9 @@
             }
         },
         "node_modules/@smithy/types": {
-            "version": "4.13.1",
-            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.13.1.tgz",
-            "integrity": "sha512-787F3yzE2UiJIQ+wYW1CVg2odHjmaWLGksnKQHUrK/lYZSEcy1msuLVvxaR/sI2/aDe9U+TBuLsXnr3vod1g0g==",
+            "version": "4.14.1",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.1.tgz",
+            "integrity": "sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3378,13 +3410,13 @@
             }
         },
         "node_modules/@smithy/url-parser": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.10.tgz",
-            "integrity": "sha512-uypjF7fCDsRk26u3qHmFI/ePL7bxxB9vKkE+2WKEciHhz+4QtbzWiHRVNRJwU3cKhrYDYQE3b0MRFtqfLYdA4A==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.2.14.tgz",
+            "integrity": "sha512-p06BiBigJ8bTA3MgnOfCtDUWnAMY0YfedO/GRpmc7p+wg3KW8vbXy1xwSu5ASy0wV7rRYtlfZOIKH4XqfhjSQQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/querystring-parser": "^4.2.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/querystring-parser": "^4.2.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3392,13 +3424,13 @@
             }
         },
         "node_modules/@smithy/util-base64": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.1.tgz",
-            "integrity": "sha512-BKGuawX4Doq/bI/uEmg+Zyc36rJKWuin3py89PquXBIBqmbnJwBBsmKhdHfNEp0+A4TDgLmT/3MSKZ1SxHcR6w==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.3.2.tgz",
+            "integrity": "sha512-XRH6b0H/5A3SgblmMa5ErXQ2XKhfbQB+Fm/oyLZ2O2kCUrwgg55bU0RekmzAhuwOjA9qdN5VU2BprOvGGUkOOQ==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.1",
-                "@smithy/util-utf8": "^4.2.1",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3406,9 +3438,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-browser": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.1.tgz",
-            "integrity": "sha512-SiJeLiozrAoCrgDBUgsVbmqHmMgg/2bA15AzcbcW+zan7SuyAVHN4xTSbq0GlebAIwlcaX32xacnrG488/J/6g==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.2.2.tgz",
+            "integrity": "sha512-JKCrLNOup3OOgmzeaKQwi4ZCTWlYR5H4Gm1r2uTMVBXoemo1UEghk5vtMi1xSu2ymgKVGW631e2fp9/R610ZjQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3418,9 +3450,9 @@
             }
         },
         "node_modules/@smithy/util-body-length-node": {
-            "version": "4.2.2",
-            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.2.tgz",
-            "integrity": "sha512-4rHqBvxtJEBvsZcFQSPQqXP2b/yy/YlB66KlcEgcH2WNoOKCKB03DSLzXmOsXjbl8dJ4OEYTn31knhdznwk7zw==",
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.2.3.tgz",
+            "integrity": "sha512-ZkJGvqBzMHVHE7r/hcuCxlTY8pQr1kMtdsVPs7ex4mMU+EAbcXppfo5NmyxMYi2XU49eqaz56j2gsk4dHHPG/g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3430,12 +3462,12 @@
             }
         },
         "node_modules/@smithy/util-buffer-from": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.1.tgz",
-            "integrity": "sha512-/swhmt1qTiVkaejlmMPPDgZhEaWb/HWMGRBheaxwuVkusp/z+ErJyQxO6kaXumOciZSWlmq6Z5mNylCd33X7Ig==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-4.2.2.tgz",
+            "integrity": "sha512-FDXD7cvUoFWwN6vtQfEta540Y/YBe5JneK3SoZg9bThSoOAC/eGeYEua6RkBgKjGa/sz6Y+DuBZj3+YEY21y4Q==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/is-array-buffer": "^4.2.1",
+                "@smithy/is-array-buffer": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3443,9 +3475,9 @@
             }
         },
         "node_modules/@smithy/util-config-provider": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.1.tgz",
-            "integrity": "sha512-462id/00U8JWFw6qBuTSWfN5TxOHvDu4WliI97qOIOnuC/g+NDAknTU8eoGXEPlLkRVgWEr03jJBLV4o2FL8+A==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-config-provider/-/util-config-provider-4.2.2.tgz",
+            "integrity": "sha512-dWU03V3XUprJwaUIFVv4iOnS1FC9HnMHDfUrlNDSh4315v0cWyaIErP8KiqGVbf5z+JupoVpNM7ZB3jFiTejvQ==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3455,14 +3487,14 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-browser": {
-            "version": "4.3.36",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.36.tgz",
-            "integrity": "sha512-R0smq7EHQXRVMxkAxtH5akJ/FvgAmNF6bUy/GwY/N20T4GrwjT633NFm0VuRpC+8Bbv8R9A0DoJ9OiZL/M3xew==",
+            "version": "4.3.49",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.3.49.tgz",
+            "integrity": "sha512-a5bNrdiONYB/qE2BuKegvUMd/+ZDwdg4vsNuuSzYE8qs2EYAdK9CynL+Rzn29PbPiUqoz/cbpRbcLzD5lEevHw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3470,17 +3502,17 @@
             }
         },
         "node_modules/@smithy/util-defaults-mode-node": {
-            "version": "4.2.39",
-            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.39.tgz",
-            "integrity": "sha512-otWuoDm35btJV1L8MyHrPl462B07QCdMTktKc7/yM+Psv6KbED/ziXiHnmr7yPHUjfIwE9S8Max0LO24Mo3ZVg==",
+            "version": "4.2.54",
+            "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.2.54.tgz",
+            "integrity": "sha512-g1cvrJvOnzeJgEdf7AE4luI7gp6L8weE0y9a9wQUSGtjb8QRHDbCJYuE4Sy0SD9N8RrnNPFsPltAz/OSoBR9Zw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/config-resolver": "^4.4.9",
-                "@smithy/credential-provider-imds": "^4.2.10",
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/property-provider": "^4.2.10",
-                "@smithy/smithy-client": "^4.12.0",
-                "@smithy/types": "^4.13.0",
+                "@smithy/config-resolver": "^4.4.17",
+                "@smithy/credential-provider-imds": "^4.2.14",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/property-provider": "^4.2.14",
+                "@smithy/smithy-client": "^4.12.13",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3488,13 +3520,13 @@
             }
         },
         "node_modules/@smithy/util-endpoints": {
-            "version": "3.3.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.3.1.tgz",
-            "integrity": "sha512-xyctc4klmjmieQiF9I1wssBWleRV0RhJ2DpO8+8yzi2LO1Z+4IWOZNGZGNj4+hq9kdo+nyfrRLmQTzc16Op2Vg==",
+            "version": "3.4.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.4.2.tgz",
+            "integrity": "sha512-a55Tr+3OKld4TTtnT+RhKOQHyPxm3j/xL4OR83WBUhLJaKDS9dnJ7arRMOp3t31dcLhApwG9bgvrRXBHlLdIkg==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/node-config-provider": "^4.3.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/node-config-provider": "^4.3.14",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3502,9 +3534,9 @@
             }
         },
         "node_modules/@smithy/util-hex-encoding": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.1.tgz",
-            "integrity": "sha512-c1hHtkgAWmE35/50gmdKajgGAKV3ePJ7t6UtEmpfCWJmQE9BQAQPz0URUVI89eSkcDqCtzqllxzG28IQoZPvwA==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-4.2.2.tgz",
+            "integrity": "sha512-Qcz3W5vuHK4sLQdyT93k/rfrUwdJ8/HZ+nMUOyGdpeGA1Wxt65zYwi3oEl9kOM+RswvYq90fzkNDahPS8K0OIg==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3514,12 +3546,12 @@
             }
         },
         "node_modules/@smithy/util-middleware": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.10.tgz",
-            "integrity": "sha512-LxaQIWLp4y0r72eA8mwPNQ9va4h5KeLM0I3M/HV9klmFaY2kN766wf5vsTzmaOpNNb7GgXAd9a25P3h8T49PSA==",
+            "version": "4.2.14",
+            "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.2.14.tgz",
+            "integrity": "sha512-1Su2vj9RYNDEv/V+2E+jXkkwGsgR7dc4sfHn9Z7ruzQHJIEni9zzw5CauvRXlFJfmgcqYP8fWa0dkh2Q2YaQyw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/types": "^4.13.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3527,13 +3559,13 @@
             }
         },
         "node_modules/@smithy/util-retry": {
-            "version": "4.2.10",
-            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.2.10.tgz",
-            "integrity": "sha512-HrBzistfpyE5uqTwiyLsFHscgnwB0kgv8vySp7q5kZ0Eltn/tjosaSGGDj/jJ9ys7pWzIP/icE2d+7vMKXLv7A==",
+            "version": "4.3.4",
+            "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.3.4.tgz",
+            "integrity": "sha512-FY1UQQ1VFmMwiYp1GVS4MeaGD5O0blLNYK0xCRHU+mJgeoH/hSY8Ld8sJWKQ6uznkh14HveRGQJncgPyNl9J+A==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/service-error-classification": "^4.2.10",
-                "@smithy/types": "^4.13.0",
+                "@smithy/service-error-classification": "^4.3.0",
+                "@smithy/types": "^4.14.1",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3541,18 +3573,18 @@
             }
         },
         "node_modules/@smithy/util-stream": {
-            "version": "4.5.15",
-            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.15.tgz",
-            "integrity": "sha512-OlOKnaqnkU9X+6wEkd7mN+WB7orPbCVDauXOj22Q7VtiTkvy7ZdSsOg4QiNAZMgI4OkvNf+/VLUC3VXkxuWJZw==",
+            "version": "4.5.25",
+            "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.5.25.tgz",
+            "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/fetch-http-handler": "^5.3.11",
-                "@smithy/node-http-handler": "^4.4.12",
-                "@smithy/types": "^4.13.0",
-                "@smithy/util-base64": "^4.3.1",
-                "@smithy/util-buffer-from": "^4.2.1",
-                "@smithy/util-hex-encoding": "^4.2.1",
-                "@smithy/util-utf8": "^4.2.1",
+                "@smithy/fetch-http-handler": "^5.3.17",
+                "@smithy/node-http-handler": "^4.6.1",
+                "@smithy/types": "^4.14.1",
+                "@smithy/util-base64": "^4.3.2",
+                "@smithy/util-buffer-from": "^4.2.2",
+                "@smithy/util-hex-encoding": "^4.2.2",
+                "@smithy/util-utf8": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3560,9 +3592,9 @@
             }
         },
         "node_modules/@smithy/util-uri-escape": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.1.tgz",
-            "integrity": "sha512-YmiUDn2eo2IOiWYYvGQkgX5ZkBSiTQu4FlDo5jNPpAxng2t6Sjb6WutnZV9l6VR4eJul1ABmCrnWBC9hKHQa6Q==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-4.2.2.tgz",
+            "integrity": "sha512-2kAStBlvq+lTXHyAZYfJRb/DfS3rsinLiwb+69SstC9Vb0s9vNWkRwpnj918Pfi85mzi42sOqdV72OLxWAISnw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3572,12 +3604,12 @@
             }
         },
         "node_modules/@smithy/util-utf8": {
-            "version": "4.2.1",
-            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.1.tgz",
-            "integrity": "sha512-DSIwNaWtmzrNQHv8g7DBGR9mulSit65KSj5ymGEIAknmIN8IpbZefEep10LaMG/P/xquwbmJ1h9ectz8z6mV6g==",
+            "version": "4.2.2",
+            "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.2.2.tgz",
+            "integrity": "sha512-75MeYpjdWRe8M5E3AW0O4Cx3UadweS+cwdXjwYGBW5h/gxxnbeZ877sLPX/ZJA9GVTlL/qG0dXP29JWFCD1Ayw==",
             "license": "Apache-2.0",
             "dependencies": {
-                "@smithy/util-buffer-from": "^4.2.1",
+                "@smithy/util-buffer-from": "^4.2.2",
                 "tslib": "^2.6.2"
             },
             "engines": {
@@ -3599,9 +3631,9 @@
             }
         },
         "node_modules/@smithy/uuid": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.1.tgz",
-            "integrity": "sha512-dSfDCeihDmZlV2oyr0yWPTUfh07suS+R5OB+FZGiv/hHyK3hrFBW5rR1UYjfa57vBsrP9lciFkRPzebaV1Qujw==",
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/@smithy/uuid/-/uuid-1.1.2.tgz",
+            "integrity": "sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==",
             "license": "Apache-2.0",
             "dependencies": {
                 "tslib": "^2.6.2"
@@ -3679,7 +3711,6 @@
             "resolved": "https://registry.npmjs.org/@types/express/-/express-4.17.25.tgz",
             "integrity": "sha512-dVd04UKsfpINUnK0yBoYHDF3xu7xVH4BuDotC/xGuycx4CgbP48X/KF/586bcObxT0HENHXEU8Nqtu6NR+eKhw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@types/body-parser": "*",
                 "@types/express-serve-static-core": "^4.17.33",
@@ -3746,8 +3777,7 @@
             "version": "7.0.15",
             "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
             "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
-            "license": "MIT",
-            "peer": true
+            "license": "MIT"
         },
         "node_modules/@types/json5": {
             "version": "0.0.29",
@@ -4079,7 +4109,6 @@
             "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "acorn": "bin/acorn"
             },
@@ -4126,7 +4155,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
             "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
                 "fast-json-stable-stringify": "^2.0.0",
@@ -4743,7 +4771,6 @@
                 }
             ],
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "baseline-browser-mapping": "^2.9.0",
                 "caniuse-lite": "^1.0.30001759",
@@ -5559,9 +5586,9 @@
             }
         },
         "node_modules/dompurify": {
-            "version": "3.3.3",
-            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.3.3.tgz",
-            "integrity": "sha512-Oj6pzI2+RqBfFG+qOaOLbFXLQ90ARpcGG6UePL82bJLtdsa6CYJD7nmiU8MW9nQNOtCHV3lZ/Bzq1X0QYbBZCA==",
+            "version": "3.4.1",
+            "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.1.tgz",
+            "integrity": "sha512-JahakDAIg1gyOm7dlgWSDjV4n7Ip2PKR55NIT6jrMfIgLFgWo81vdr1/QGqWtFNRqXP9UV71oVePtjqS2ebnPw==",
             "dev": true,
             "license": "(MPL-2.0 OR Apache-2.0)",
             "optionalDependencies": {
@@ -5671,7 +5698,6 @@
             "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "ansi-colors": "^4.1.1",
                 "strip-ansi": "^6.0.1"
@@ -5879,7 +5905,6 @@
             "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.2.0",
                 "@eslint-community/regexpp": "^4.6.1",
@@ -6046,7 +6071,6 @@
             "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@rtsao/scc": "^1.1.0",
                 "array-includes": "^3.1.9",
@@ -6396,7 +6420,6 @@
             "resolved": "https://registry.npmjs.org/express/-/express-4.22.1.tgz",
             "integrity": "sha512-F2X8g9P1X7uCPZMA3MVf9wcTqlyNp7IhH5qPCI0izhaOIYXaW9L535tGA3qmjRzpH+bZczqq7hVKxTR4NWnu+g==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "accepts": "~1.3.8",
                 "array-flatten": "1.1.1",
@@ -6495,7 +6518,6 @@
             "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.18.0.tgz",
             "integrity": "sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.3",
                 "fast-uri": "^3.0.1",
@@ -6627,9 +6649,9 @@
             }
         },
         "node_modules/fast-xml-builder": {
-            "version": "1.1.4",
-            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.4.tgz",
-            "integrity": "sha512-f2jhpN4Eccy0/Uz9csxh3Nu6q4ErKxf0XIsasomfOihuSUa3/xw6w8dnOtCDgEItQFJG8KyXPzQXzcODDrrbOg==",
+            "version": "1.1.5",
+            "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.1.5.tgz",
+            "integrity": "sha512-4TJn/8FKLeslLAH3dnohXqE3QSoxkhvaMzepOIZytwJXZO69Bfz0HBdDHzOTOon6G59Zrk6VQ2bEiv1t61rfkA==",
             "funding": [
                 {
                     "type": "github",
@@ -6642,9 +6664,9 @@
             }
         },
         "node_modules/fast-xml-parser": {
-            "version": "5.5.7",
-            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.5.7.tgz",
-            "integrity": "sha512-LteOsISQ2GEiDHZch6L9hB0+MLoYVLToR7xotrzU0opCICBkxOPgHAy1HxAvtxfJNXDJpgAsQN30mkrfpO2Prg==",
+            "version": "5.7.1",
+            "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.1.tgz",
+            "integrity": "sha512-8Cc3f8GUGUULg34pBch/KGyPLglS+OFs05deyOlY7fL2MTagYPKrVQNmR1fLF/yJ9PH5ZSTd3YDF6pnmeZU+zA==",
             "funding": [
                 {
                     "type": "github",
@@ -6653,9 +6675,10 @@
             ],
             "license": "MIT",
             "dependencies": {
-                "fast-xml-builder": "^1.1.4",
-                "path-expression-matcher": "^1.1.3",
-                "strnum": "^2.2.0"
+                "@nodable/entities": "^2.1.0",
+                "fast-xml-builder": "^1.1.5",
+                "path-expression-matcher": "^1.5.0",
+                "strnum": "^2.2.3"
             },
             "bin": {
                 "fxparser": "src/cli/cli.js"
@@ -9820,7 +9843,6 @@
             "integrity": "sha512-UczzB+0nnwGotYSgllfARAqWCJ5e/skuV2K/l+Zyck/H6pJIhLXuBnz+6vn2i211o7DtbE78HQtsYEKICHGI+g==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/mobx"
@@ -10456,14 +10478,14 @@
             }
         },
         "node_modules/openapi-sampler": {
-            "version": "1.7.1",
-            "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.1.tgz",
-            "integrity": "sha512-pKFRROcYyxRt9GIn0NmS+GkWPS19l0CLQRYAnHk4m1Qp+G43ssVNcfRMs1sLkGrVMuFWO4P4F6YMXeXnfyFGuQ==",
+            "version": "1.7.2",
+            "resolved": "https://registry.npmjs.org/openapi-sampler/-/openapi-sampler-1.7.2.tgz",
+            "integrity": "sha512-OKytvqB5XIaTgA9xtw8W8UTar+uymW2xPVpFN0NihMtuHPdPTGxBEhGnfFnJW5g/gOSIvkP+H0Xh3XhVI9/n7g==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@types/json-schema": "^7.0.7",
-                "fast-xml-parser": "^5.3.8",
+                "fast-xml-parser": "^5.5.1",
                 "json-pointer": "0.6.2"
             }
         },
@@ -10644,9 +10666,9 @@
             }
         },
         "node_modules/path-expression-matcher": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.2.0.tgz",
-            "integrity": "sha512-DwmPWeFn+tq7TiyJ2CxezCAirXjFxvaiD03npak3cRjlP9+OjTmSy1EpIrEbh+l6JgUundniloMLDQ/6VTdhLQ==",
+            "version": "1.5.0",
+            "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+            "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
             "funding": [
                 {
                     "type": "github",
@@ -10740,7 +10762,6 @@
             "resolved": "https://registry.npmjs.org/pg/-/pg-8.18.0.tgz",
             "integrity": "sha512-xqrUDL1b9MbkydY/s+VZ6v+xiMUmOUk7SS9d/1kpyQxoJ6U9AO1oIJyUWVZojbfe5Cc/oluutcgFG4L9RDP1iQ==",
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "pg-connection-string": "^2.11.0",
                 "pg-pool": "^3.11.0",
@@ -11137,7 +11158,6 @@
             "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "bin": {
                 "prettier": "bin-prettier.js"
             },
@@ -11254,9 +11274,9 @@
             "license": "MIT"
         },
         "node_modules/protobufjs": {
-            "version": "7.5.4",
-            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.4.tgz",
-            "integrity": "sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==",
+            "version": "7.5.5",
+            "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.5.tgz",
+            "integrity": "sha512-3wY1AxV+VBNW8Yypfd1yQY9pXnqTAN+KwQxL8iYm3/BjKYMNg4i0owhEe26PWDOMaIrzeeF98Lqd5NGz4omiIg==",
             "dev": true,
             "hasInstallScript": true,
             "license": "BSD-3-Clause",
@@ -11550,7 +11570,6 @@
             "integrity": "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -11561,7 +11580,6 @@
             "integrity": "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "scheduler": "^0.27.0"
             },
@@ -12814,9 +12832,9 @@
             }
         },
         "node_modules/strnum": {
-            "version": "2.2.1",
-            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.1.tgz",
-            "integrity": "sha512-BwRvNd5/QoAtyW1na1y1LsJGQNvRlkde6Q/ipqqEaivoMdV+B1OMOTVdwR+N/cwVUcIt9PYyHmV8HyexCZSupg==",
+            "version": "2.2.3",
+            "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.2.3.tgz",
+            "integrity": "sha512-oKx6RUCuHfT3oyVjtnrmn19H1SiCqgJSg+54XqURKp5aCMbrXrhLjRN9TjuwMjiYstZ0MzDrHqkGZ5dFTKd+zg==",
             "funding": [
                 {
                     "type": "github",
@@ -12831,7 +12849,6 @@
             "integrity": "sha512-J72R4ltw0UBVUlEjTzI0gg2STOqlI9JBhQOL4Dxt7aJOnnSesy0qJDn4PYfMCafk9cWOaVg129Pesl5o+DIh0Q==",
             "dev": true,
             "license": "MIT",
-            "peer": true,
             "dependencies": {
                 "@emotion/is-prop-valid": "1.4.0",
                 "@emotion/unitless": "0.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "data-capture-service",
-    "version": "9.8.9",
+    "version": "9.8.10",
     "engines": {
         "npm": ">=11.12.1",
         "node": ">=24.15.0"

--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
     "name": "data-capture-service",
     "version": "9.8.9",
     "engines": {
-        "npm": ">=10.8.2",
-        "node": ">=24.13.0"
+        "npm": ">=11.12.1",
+        "node": ">=24.15.0"
     },
     "scripts": {
         "start": "node ./bin/www",
@@ -71,7 +71,6 @@
         "yamljs": "^0.3.0"
     },
     "overrides": {
-        "fast-xml-parser": "5.5.7",
         "js-yaml": "4.1.1"
     },
     "license": "MIT"


### PR DESCRIPTION
Two different scan set up:

- `snyk_app_scan  `: scans the app's dependencies (package.json) for known CVEs. Runs early in the pipeline before building the Docker image.
- The Snyk container scan in the build job: scans the built Docker image including the OS, Node runtime, and npm itself.

Two different monitoring set up:

- `snyk_monitor` : monitoring the app dependencies (only prod deployment branch)
- `snyk_container_monitor`: monitoring the built img (only prod deployment branch)

This PR also includes an upgrade to node `24.15.0` to fix some flagged vulnerabilities, and an upgrade to npm `11.13.0` in the Dockerfile due to the base img (node 24.15.0) using older vulnerable npm version.

npm in package.json is upgraded to `11.12.1` which is the supported version in node `24.15.0`